### PR TITLE
Replace iree-compile subprocess with compiler C API dynamic loading

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Python package
         run: |
           ONNXRUNTIME_EP_IREE_BUILD_DIR=${{ github.workspace }}/${BUILD_DIR} \
-            pip install -e python/
+            pip install python/
 
       - name: Run tests
         run: pytest test/ -v

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Python package
         run: |
           $env:ONNXRUNTIME_EP_IREE_BUILD_DIR = "${{ github.workspace }}\${{ env.BUILD_DIR }}"
-          pip install -e python/
+          pip install python/
 
       - name: Run tests
         run: pytest test/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,10 @@ jobs:
       - name: Install Python package
         run: |
           ONNXRUNTIME_EP_IREE_BUILD_DIR=${{ github.workspace }}/${BUILD_DIR} \
-            pip install -e python/
+            pip install python/
 
       - name: Run tests
         run: pytest test/ -v
 
       - name: Run ExternDispatch tests
-        run: |
-          pytest test/test_extern_dispatch.py \
-            --ep-lib ${{ github.workspace }}/${BUILD_DIR}/libonnxruntime_ep_iree.so \
-            -v
+        run: pytest test/test_extern_dispatch.py -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,9 @@ endif()
 # When not specified, FetchContent the IREE sources from GitHub at the tag
 # specified by `IREE_GIT_TAG`.
 #
-# We choose not to take a source dependency on the IREE compiler, which is
-# quite heavy and can be slow to build. It is left to the consumer of the EP to
-# make sure iree compiler tooling scripts are available in their environment.
-# This can be generally done by `pip install iree-base-compiler`.
-
-# We may in future decide to build the IREE compiler from source.
+# The EP dynamically loads libIREECompiler.so at runtime via dlopen (no
+# compile-time linking to the compiler). The loader source and C API headers
+# come from the IREE source tree (compiler/bindings/c/).
 #
 ################################################################################
 
@@ -81,7 +78,7 @@ set(IREE_GIT_TAG "v3.10.0")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 
 # Set IREE build flags.
-set(IREE_VISIBILITY_HIDDEN OFF)
+set(IREE_VISIBILITY_HIDDEN ON)
 set(IREE_BUILD_COMPILER OFF)
 set(IREE_BUILD_TESTS OFF)
 set(IREE_BUILD_SAMPLES OFF)
@@ -103,6 +100,9 @@ endif()
 
 if(IREE_SOURCE_DIR)
   message(STATUS "Using existing IREE sources: ${IREE_SOURCE_DIR}")
+  # Normalize so downstream code can use iree_SOURCE_DIR unconditionally
+  # (FetchContent sets this automatically; local source needs it explicitly).
+  set(iree_SOURCE_DIR "${IREE_SOURCE_DIR}")
   add_subdirectory(${IREE_SOURCE_DIR} iree SYSTEM EXCLUDE_FROM_ALL)
 else()
   message(STATUS "Fetching IREE sources from tag ${IREE_GIT_TAG}")
@@ -131,6 +131,65 @@ else()
   endif()
 endif()
 
+################################################################################
+# Compiler Loader
+#
+# The EP uses the IREE compiler C API (embedding_api.h) via a dynamic loader
+# (loader.h / loader.cpp). At runtime, the EP loads libIREECompiler.so via
+# dlopen — there is no compile-time linking to the compiler. The loader source
+# and C API headers come from the IREE source tree.
+#
+# At runtime, the compiler library is resolved in this order:
+#   1. Session option: ep.iree.compiler_lib_path (explicit path)
+#   2. Env var: IREE_EP_COMPILER_LIB (full path to library file)
+#   3. Env var: IREE_EP_COMPILER_LIB_DIR (directory to search)
+#   4. Relative to EP .so: iree/compiler/_mlir_libs/ (pip co-installs)
+#   5. Fallback: dlopen("libIREECompiler.so") via standard search paths
+#
+################################################################################
+
+# Helper: check whether a Python module is importable in the active environment.
+# Sets ${result_var} to TRUE/FALSE in the caller's scope.
+function(check_python_import module result_var)
+  set(Python3_FIND_VIRTUALENV FIRST)
+  find_package(Python3 COMPONENTS Interpreter QUIET)
+  unset(Python3_FIND_VIRTUALENV)
+  if(NOT Python3_FOUND)
+    message(STATUS "Python3 interpreter not found; skipping ${module} check")
+    set(${result_var} FALSE PARENT_SCOPE)
+    return()
+  endif()
+  execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -c
+      "import importlib.util; exit(0 if importlib.util.find_spec('${module}') else 1)"
+    RESULT_VARIABLE _import_result
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(_import_result EQUAL 0)
+    set(${result_var} TRUE PARENT_SCOPE)
+  else()
+    set(${result_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Check for iree-base-compiler. Not required at build time — the EP discovers
+# libIREECompiler.so at runtime. A warning is printed if not found.
+# Use iree.compiler._mlir_libs (not iree.compiler) because the IREE build tree
+# creates a namespace package that makes find_spec('iree.compiler') succeed
+# even without iree-base-compiler installed.
+check_python_import("iree.compiler._mlir_libs" _iree_compiler_installed)
+if(_iree_compiler_installed)
+  message(STATUS "iree-base-compiler is installed")
+else()
+  message(WARNING
+    "iree-base-compiler is not installed in the active Python environment.\n"
+    "The EP will still build but will fail to compile models at runtime unless "
+    "iree-base-compiler is installed or IREE_EP_COMPILER_LIB / "
+    "IREE_EP_COMPILER_LIB_DIR env var is set.")
+endif()
+
+set(IREE_COMPILER_BINDINGS_DIR "${iree_SOURCE_DIR}/compiler/bindings/c")
+
 # Build shared library (EP plugin)
 add_library(onnxruntime_ep_iree SHARED
   src/plugin_entry.cc
@@ -145,20 +204,61 @@ add_library(onnxruntime_ep_iree SHARED
   src/temp_file.cc
 )
 
+# Build IREE compiler loader as a static library. The loader's trampoline
+# functions use IREE_EMBED_EXPORTED (visibility("default")) which we can't
+# override at compile time. Instead, --exclude-libs localizes all symbols
+# from this archive when linking into our shared library.
+add_library(iree_compiler_loader STATIC
+  ${IREE_COMPILER_BINDINGS_DIR}/iree/compiler/loader/loader.cpp
+)
+set_target_properties(iree_compiler_loader PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(iree_compiler_loader PRIVATE
+  ${IREE_COMPILER_BINDINGS_DIR}
+)
+if(MSVC)
+  target_compile_options(iree_compiler_loader PRIVATE /w)
+else()
+  target_compile_options(iree_compiler_loader PRIVATE -w)
+endif()
+
 # Statically link IREE runtime and io/parameter libraries.
+# Link dl for dlopen/dlsym (compiler loader).
 target_link_libraries(onnxruntime_ep_iree PRIVATE
   iree_runtime_unified
   iree_io_parameter_index
   iree_io_parameter_index_provider
   iree_io_formats_irpa_irpa
   iree_modules_io_parameters_parameters
+  iree_compiler_loader
+  ${CMAKE_DL_LIBS}
 )
 
+# Localize all symbols from the compiler loader static library so its
+# IREE_EMBED_EXPORTED trampolines don't leak into our public symbol table.
+if(UNIX AND NOT APPLE)
+  # GNU ld: hide all symbols from the loader's static archive.
+  target_link_options(onnxruntime_ep_iree PRIVATE
+    "LINKER:--exclude-libs,libiree_compiler_loader.a"
+  )
+elseif(APPLE)
+  # macOS ld: generate an unexported symbols list from the loader's trampolines.
+  # The ireeCompiler* symbols are generated by loader.cpp with
+  # visibility("default") — we re-hide them here.
+  set(_unexport_file "${CMAKE_CURRENT_BINARY_DIR}/iree_loader_unexported.txt")
+  file(WRITE "${_unexport_file}" "_ireeCompiler*\n")
+  target_link_options(onnxruntime_ep_iree PRIVATE
+    "LINKER:-unexported_symbols_list,${_unexport_file}"
+  )
+endif()
+# On Windows, MSVC only exports symbols explicitly marked __declspec(dllexport),
+# so the loader trampolines (which use visibility("default"), a no-op on MSVC)
+# are not exported. No additional linker flags needed.
 
 # Include directories
 target_include_directories(onnxruntime_ep_iree PRIVATE
   ${IREE_EP_ONNX_SRC_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${IREE_COMPILER_BINDINGS_DIR}
 )
 
 # Compiler flags
@@ -177,23 +277,15 @@ else()
   )
 endif()
 
-# Export symbols for plugin loading
-if(MSVC)
-  # Windows: Use .def file (ORT_EXPORT is defined as empty in ORT headers on Windows)
-  set_target_properties(onnxruntime_ep_iree PROPERTIES
-    LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/src/symbols.def"
-  )
-elseif(UNIX AND NOT APPLE)
-  # Linux: Use version script
-  set_target_properties(onnxruntime_ep_iree PROPERTIES
-    LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/symbols.lds"
-  )
-elseif(APPLE)
-  # macOS: Export all symbols
-  set_target_properties(onnxruntime_ep_iree PROPERTIES
-    LINK_FLAGS "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/src/symbols.txt"
-  )
-endif()
+# Hide all symbols by default. Only plugin entry points (CreateEpFactories,
+# ReleaseEpFactory) are exported via explicit visibility("default") attributes.
+# VISIBILITY_INLINES_HIDDEN suppresses weak inline/template symbols (e.g.
+# std::format, libstdc++ internals) that would otherwise leak into the ABI.
+set_target_properties(onnxruntime_ep_iree PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  C_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN ON
+)
 
 # Install
 install(TARGETS onnxruntime_ep_iree

--- a/python/onnxruntime_ep_iree/__init__.py
+++ b/python/onnxruntime_ep_iree/__init__.py
@@ -5,7 +5,11 @@ Provides functions to locate the native EP shared library and its registration n
 
 from pathlib import Path
 
-__all__ = ["get_library_path", "get_ep_name", "get_ep_names"]
+__all__ = [
+    "get_library_path",
+    "get_ep_name",
+    "get_ep_names",
+]
 
 _LIB_NAMES = [
     "libonnxruntime_ep_iree.dylib",

--- a/src/iree_compile.cc
+++ b/src/iree_compile.cc
@@ -6,40 +6,295 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// MLIR to VMFB compilation via iree-compile CLI.
+// In-process MLIR-to-VMFB compilation via the IREE compiler C API.
+// The compiler shared library is loaded dynamically at runtime.
 //
 //===----------------------------------------------------------------------===//
 
 #include "iree_compile.h"
 
-#include <cstdlib>
+#include <filesystem>
 #include <format>
-#include <numeric>
+#include <mutex>
 #include <string>
+#include <vector>
+
+#include "iree/compiler/embedding_api.h"
+#include "iree/compiler/loader.h"
+#include "platform_utils.h"
 
 namespace onnxruntime::iree {
 
-OrtStatus* CompileToVmfb(const std::string& mlir_path,
-                         const std::string& vmfb_path,
-                         const std::vector<std::string>& flags,
-                         const OrtApi& /*ort_api*/) {
-  // Build command: iree-compile {mlir_path} {flags} -o {vmfb_path}
-  std::string flags_str = std::accumulate(
-      flags.begin(), flags.end(), std::string(),
-      [](const std::string& a, const std::string& b) { return a + " " + b; });
-  std::string command = std::format(R"(iree-compile "{}" {} -o "{}")",
-                                    mlir_path, flags_str, vmfb_path);
+// RAII scope guard for arbitrary cleanup.
+template <typename F>
+struct ScopeExit {
+  F cleanup;
+  explicit ScopeExit(F f) : cleanup(std::move(f)) {}
+  ~ScopeExit() { cleanup(); }
+  ScopeExit(const ScopeExit&) = delete;
+  ScopeExit& operator=(const ScopeExit&) = delete;
+};
+template <typename F>
+ScopeExit<F> MakeScopeExit(F f) {
+  return ScopeExit<F>(std::move(f));
+}
 
-  // Execute the command.
-  int result = std::system(command.c_str());
+// Compiler state token — existence means the compiler is loaded and
+// initialized. Destructor calls ireeCompilerGlobalShutdown() at EP DSO unload
+// (when the process-global unique_ptr is destroyed).
+//
+// Ordering guarantee: libIREECompiler.so is guaranteed to still be loaded
+// when this destructor runs because the IREE loader (loader.cpp) intentionally
+// never calls dlclose — the handle is leaked and libIREECompiler.so persists
+// until process exit.
+//
+// Unloading and reloading the EP in the same process is not supported — the
+// IREE final shutdown permanently disables the compiler for the process.
+struct CompilerState {
+  ~CompilerState() { ireeCompilerGlobalShutdown(); }
+};
 
-  if (result != 0) {
-    std::string error_msg = std::format(
-        R"(IREE EP: iree-compile failed with exit code {}. Command: {})",
-        result, command);
-    return Ort::Status(error_msg.c_str(), ORT_FAIL).release();
+static std::mutex s_mutex;                      // Protects s_state.
+static std::unique_ptr<CompilerState> s_state;  // Non-null iff initialized.
+
+// Platform-specific compiler library names.
+static constexpr const char* kCompilerLibNames[] = {
+#if defined(__APPLE__)
+    "libIREECompiler.dylib",
+#elif defined(_WIN32)
+    "IREECompiler.dll",
+#else
+    "libIREECompiler.so",
+#endif
+};
+
+// Try to find the compiler library relative to our own shared library.
+// For pip installs, both the EP and the compiler are under site-packages:
+//   site-packages/onnxruntime_ep_iree/libonnxruntime_ep_iree.so
+//   site-packages/iree/compiler/_mlir_libs/libIREECompiler.so
+//
+// For editable installs, the EP is in a build/ directory and the compiler
+// is in the venv's site-packages. We walk up looking for iree/compiler/.
+static std::string FindCompilerLibRelativeToSelf() {
+  std::string self_lib = GetSelfLibraryPath();
+  if (self_lib.empty()) {
+    return {};
   }
 
+  std::filesystem::path self_path(self_lib);
+  // Walk up to find a directory that contains iree/compiler/_mlir_libs/.
+  // Start from our parent dir and go up a few levels.
+  for (auto dir = self_path.parent_path(); dir.has_parent_path();
+       dir = dir.parent_path()) {
+    for (const char* name : kCompilerLibNames) {
+      auto candidate = dir / "iree" / "compiler" / "_mlir_libs" / name;
+      if (std::filesystem::exists(candidate)) {
+        return candidate.string();
+      }
+    }
+    // Don't walk above the filesystem root or too many levels.
+    if (dir == dir.parent_path()) break;
+  }
+  return {};
+}
+
+// Search a directory for a compiler library file. Returns full path or empty.
+static std::string FindLibInDir(const std::filesystem::path& dir) {
+  for (const char* name : kCompilerLibNames) {
+    auto candidate = dir / name;
+    if (std::filesystem::exists(candidate)) {
+      return candidate.string();
+    }
+  }
+  return {};
+}
+
+// Resolve the compiler library path using the discovery chain.
+// Returns the resolved path and appends all attempted locations to `attempts`
+// for diagnostic purposes.
+static std::string ResolveCompilerLibPath(const std::string& explicit_path,
+                                          std::vector<std::string>& attempts) {
+  // 1. Explicit path from caller (session option ep.iree.compiler_lib_path).
+  if (!explicit_path.empty()) {
+    attempts.push_back(std::format("session option: {}", explicit_path));
+    return explicit_path;
+  }
+
+  // 2. Runtime environment variable override.
+  //    IREE_EP_COMPILER_LIB — full path to the library file.
+  //    IREE_EP_COMPILER_LIB_DIR — directory to search.
+  std::string env_lib = GetEnv("IREE_EP_COMPILER_LIB");
+  if (!env_lib.empty()) {
+    attempts.push_back(std::format("env IREE_EP_COMPILER_LIB: {}", env_lib));
+    return env_lib;
+  }
+  std::string env_dir = GetEnv("IREE_EP_COMPILER_LIB_DIR");
+  if (!env_dir.empty()) {
+    std::string found = FindLibInDir(env_dir);
+    attempts.push_back(
+        std::format("env IREE_EP_COMPILER_LIB_DIR: {}", env_dir));
+    if (!found.empty()) return found;
+  }
+
+  // 3. Search relative to our own .so (pip-installed iree-base-compiler).
+  std::string relative = FindCompilerLibRelativeToSelf();
+  if (!relative.empty()) {
+    attempts.push_back(std::format("relative to EP library: {}", relative));
+    return relative;
+  }
+  attempts.push_back("relative to EP library: (not found)");
+
+  // 4. Bare library name — rely on standard dlopen search paths.
+  attempts.push_back(std::format("dlopen fallback: {}", kCompilerLibNames[0]));
+  return kCompilerLibNames[0];
+}
+
+/*static*/
+OrtStatus* IreeCompiler::Initialize(const std::string& library_path) {
+  std::lock_guard<std::mutex> lock(s_mutex);
+  if (s_state) return nullptr;
+
+  std::vector<std::string> attempts;
+  std::string resolved = ResolveCompilerLibPath(library_path, attempts);
+
+  if (!ireeCompilerLoadLibrary(resolved.c_str())) {
+    // Do not cache this error — no IREE global state was set up, so the
+    // caller may retry with a different path (e.g. a corrected session option).
+    std::string msg = std::format(
+        "IREE EP: Failed to load compiler library '{}'. Search order:\n",
+        resolved);
+    for (size_t i = 0; i < attempts.size(); ++i) {
+      msg += std::format("  {}. {}\n", i + 1, attempts[i]);
+    }
+    msg +=
+        "Ensure iree-base-compiler is installed or set "
+        "IREE_EP_COMPILER_LIB_DIR / ep.iree.compiler_lib_path.";
+    return Ort::Status(msg.c_str(), ORT_FAIL).release();
+  }
+
+  ireeCompilerGlobalInitialize();
+  s_state = std::make_unique<CompilerState>();
+  return nullptr;
+}
+
+/*static*/
+bool IreeCompiler::IsInitialized() {
+  std::lock_guard<std::mutex> lock(s_mutex);
+  return s_state != nullptr;
+}
+
+/*static*/
+OrtStatus* IreeCompiler::CompileToVmfb(const std::string& mlir_path,
+                                       const std::string& vmfb_path,
+                                       const std::vector<std::string>& flags) {
+  {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    if (!s_state) {
+      return Ort::Status(
+                 "IREE EP: Compiler not initialized. Call "
+                 "IreeCompiler::Initialize() first.",
+                 ORT_FAIL)
+          .release();
+    }
+  }
+
+  iree_compiler_session_t* session = nullptr;
+  iree_compiler_invocation_t* inv = nullptr;
+  iree_compiler_output_t* output = nullptr;
+  auto on_exit = MakeScopeExit([&]() {
+    if (output) ireeCompilerOutputDestroy(output);
+    if (inv) ireeCompilerInvocationDestroy(inv);
+    if (session) ireeCompilerSessionDestroy(session);
+  });
+
+  // 1. Create a compiler session.
+  session = ireeCompilerSessionCreate();
+  if (!session) {
+    return Ort::Status("IREE EP: Failed to create compiler session.", ORT_FAIL)
+        .release();
+  }
+
+  // 2. Set compilation flags on the session.
+  if (!flags.empty()) {
+    std::vector<const char*> argv;
+    argv.reserve(flags.size());
+    for (const auto& f : flags) {
+      argv.push_back(f.c_str());
+    }
+    iree_compiler_error_t* err = ireeCompilerSessionSetFlags(
+        session, static_cast<int>(argv.size()), argv.data());
+    if (err) {
+      std::string msg = std::format("IREE EP: Failed to set compiler flags: {}",
+                                    ireeCompilerErrorGetMessage(err));
+      ireeCompilerErrorDestroy(err);
+      return Ort::Status(msg.c_str(), ORT_FAIL).release();
+    }
+  }
+
+  // 3. Create an invocation and enable diagnostics.
+  inv = ireeCompilerInvocationCreate(session);
+  if (!inv) {
+    return Ort::Status("IREE EP: Failed to create compiler invocation (OOM?).",
+                       ORT_FAIL)
+        .release();
+  }
+  ireeCompilerInvocationEnableConsoleDiagnostics(inv);
+
+  // 4. Open the MLIR source file.
+  iree_compiler_source_t* source = nullptr;
+  iree_compiler_error_t* err =
+      ireeCompilerSourceOpenFile(session, mlir_path.c_str(), &source);
+  if (err) {
+    std::string msg =
+        std::format("IREE EP: Failed to open MLIR source '{}': {}", mlir_path,
+                    ireeCompilerErrorGetMessage(err));
+    ireeCompilerErrorDestroy(err);
+    return Ort::Status(msg.c_str(), ORT_FAIL).release();
+  }
+
+  // 5. Parse the MLIR source. On success, inv takes ownership of source and
+  // destroys it when inv is destroyed (via on_exit). On failure, source is not
+  // consumed and must be destroyed explicitly.
+  if (!ireeCompilerInvocationParseSource(inv, source)) {
+    ireeCompilerSourceDestroy(source);
+    return Ort::Status(std::format("IREE EP: Failed to parse MLIR source '{}'",
+                                   mlir_path)
+                           .c_str(),
+                       ORT_FAIL)
+        .release();
+  }
+
+  // 6. Run the standard compilation pipeline.
+  if (!ireeCompilerInvocationPipeline(inv, IREE_COMPILER_PIPELINE_STD)) {
+    return Ort::Status(
+               "IREE EP: Compilation pipeline failed. "
+               "Check console diagnostics for details.",
+               ORT_FAIL)
+        .release();
+  }
+
+  // 7. Write the compiled VMFB output to file.
+  err = ireeCompilerOutputOpenFile(vmfb_path.c_str(), &output);
+  if (err) {
+    std::string msg =
+        std::format("IREE EP: Failed to open output file '{}': {}", vmfb_path,
+                    ireeCompilerErrorGetMessage(err));
+    ireeCompilerErrorDestroy(err);
+    return Ort::Status(msg.c_str(), ORT_FAIL).release();
+  }
+
+  err = ireeCompilerInvocationOutputVMBytecode(inv, output);
+  if (err) {
+    std::string msg = std::format("IREE EP: Failed to emit VM bytecode: {}",
+                                  ireeCompilerErrorGetMessage(err));
+    ireeCompilerErrorDestroy(err);
+    return Ort::Status(msg.c_str(), ORT_FAIL).release();
+  }
+
+  // 8. Keep the output file (without this, it's deleted on destroy).
+  ireeCompilerOutputKeep(output);
+
+  // on_exit destroys output (file kept), inv, and session.
   return nullptr;
 }
 

--- a/src/iree_compile.h
+++ b/src/iree_compile.h
@@ -6,8 +6,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Provides a function to compile MLIR files to IREE VMFB bytecode by invoking
-// the iree-compile tool as a subprocess.
+// Provides in-process MLIR-to-VMFB compilation via the IREE compiler C API.
+// The compiler shared library (libIREECompiler.so) is loaded dynamically at
+// runtime — no compile-time linking to the compiler is required.
 //
 //===----------------------------------------------------------------------===//
 
@@ -15,26 +16,66 @@
 #define ONNXRUNTIME_EP_IREE_SRC_IREE_COMPILE_H_
 
 #include <string>
+#include <vector>
 
 #include "ort_import.h"
 
 namespace onnxruntime::iree {
 
-// Compiles MLIR to VMFB using iree-compile CLI.
+// Manages the IREE compiler lifecycle and provides compilation.
 //
-// Args:
-//   mlir_path: Path to the input MLIR file.
-//   vmfb_path: Path where the output VMFB should be written.
-//   flags: Additional flags to pass to iree-compile (e.g.,
-//          ["--iree-hal-target-device=local", "--iree-input-type=onnx"]).
-//   ort_api: ORT API for creating status objects.
+// The compiler is a process-global singleton — Initialize() loads the shared
+// library once for the lifetime of the process. All state is protected by an
+// internal mutex.
 //
-// Returns:
-//   nullptr on success, OrtStatus* with error message on failure.
-OrtStatus* CompileToVmfb(const std::string& mlir_path,
-                         const std::string& vmfb_path,
-                         const std::vector<std::string>& flags,
-                         const OrtApi& ort_api);
+// Thread safety:
+//   Initialize()    — Thread-safe. Multiple threads may call concurrently;
+//     exactly one performs initialization. Load failures are not cached —
+//     the caller may retry with a different path.
+//   IsInitialized() — Thread-safe.
+//   CompileToVmfb() — Thread-safe (each call creates its own compiler
+//     session/invocation). Requires successful Initialize() first.
+//
+// Lifetime: ireeCompilerGlobalShutdown() is called automatically via RAII when
+// the process-global CompilerState is destroyed at EP DSO unload. This is safe
+// because the IREE loader intentionally never calls dlclose, so libIREECompiler
+// .so persists until process exit regardless of EP DSO lifetime. The IREE C
+// API's final shutdown permanently disables the compiler for the process, so
+// unloading and reloading the EP plugin in the same process is not supported.
+class IreeCompiler {
+ public:
+  // Load the compiler shared library and initialize global state.
+  //
+  // library_path: absolute path to libIREECompiler.so/.dylib/IREECompiler.dll.
+  //   If empty, auto-discovers the library using this search order:
+  //     1. Session option ep.iree.compiler_lib_path (passed as library_path)
+  //     2. Environment variable IREE_EP_COMPILER_LIB (full path to library)
+  //     3. Environment variable IREE_EP_COMPILER_LIB_DIR (directory to search)
+  //     4. pip-installed iree-base-compiler (relative to EP shared library)
+  //     5. Bare dlopen("libIREECompiler.so") via standard search paths
+  //
+  // Thread-safe. First successful call wins; subsequent calls are no-ops.
+  // On failure, returns an error and allows the caller to retry with a
+  // different path (no IREE global state is set up on load failure).
+  static OrtStatus* Initialize(const std::string& library_path);
+
+  // Returns true if Initialize() has been called successfully.
+  static bool IsInitialized();
+
+  // Compile an MLIR file to VMFB bytecode using the IREE compiler C API.
+  //
+  // Args:
+  //   mlir_path: Path to the input MLIR file.
+  //   vmfb_path: Path where the output VMFB should be written.
+  //   flags: Compiler flags (e.g., ["--iree-hal-target-device=hip",
+  //          "--iree-hip-target=gfx1100"]).
+  //
+  // Returns nullptr on success, OrtStatus* with error message on failure.
+  // Requires successful Initialize() first.
+  static OrtStatus* CompileToVmfb(const std::string& mlir_path,
+                                  const std::string& vmfb_path,
+                                  const std::vector<std::string>& flags);
+};
 
 }  // namespace onnxruntime::iree
 

--- a/src/iree_ep.cc
+++ b/src/iree_ep.cc
@@ -279,7 +279,7 @@ OrtStatus* ORT_API_CALL IreeEp::CompileImpl(
   ORT_CXX_LOG_NOEXCEPT(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                        "IREE EP: Generating VMFB");
   ORT_RETURN_IF_ERROR(
-      CompileToVmfb(mlir_file.Path(), vmfb_file.Path(), flags, ep->ort_api));
+      IreeCompiler::CompileToVmfb(mlir_file.Path(), vmfb_file.Path(), flags));
   ORT_CXX_LOG_NOEXCEPT(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                        "IREE EP: VMFB Generated Successfully");
 

--- a/src/iree_ep_factory.cc
+++ b/src/iree_ep_factory.cc
@@ -17,6 +17,7 @@
 #include <mutex>
 
 #include "iree_allocator.h"
+#include "iree_compile.h"
 #include "iree_data_transfer.h"
 #include "iree_ep.h"
 
@@ -199,6 +200,10 @@ IreeEpFactory::~IreeEpFactory() {
   // Note: Avoid excessive logging during cleanup - ORT logging infrastructure
   // may be torn down before our destructors run during Python interpreter
   // shutdown.
+
+  // The compiler is process-global (loaded via dlopen). ireeCompilerGlobal-
+  // Shutdown() is called automatically at EP DSO unload via RAII on the
+  // static CompilerState. Do not call it here.
 
   // Clean up in proper order: allocators first (they reference devices),
   // then data transfer, then devices, finally hardware devices.
@@ -401,6 +406,7 @@ OrtStatus* ORT_API_CALL IreeEpFactory::CreateEpImpl(
   // Parse configuration from session options config entries.
   // The Python API stores options with "ep.iree." prefix.
   IreeEp::Config config = {};
+  std::string compiler_lib_path;
   if (session_options != nullptr) {
     Ort::ConstSessionOptions sess_opts(session_options);
     config.target_arch =
@@ -420,6 +426,29 @@ OrtStatus* ORT_API_CALL IreeEpFactory::CreateEpImpl(
     if (!dim_specs_str.empty()) {
       ORT_RETURN_IF_ERROR(
           ParseDimSpecs(dim_specs_str, config.dim_spec_variants));
+    }
+
+    // compiler_lib_path is a process-global setting (first init wins), not
+    // per-session. It's parsed here because session options are the only way
+    // to pass it from the Python API.
+    compiler_lib_path =
+        sess_opts.GetConfigEntryOrDefault("ep.iree.compiler_lib_path", "");
+  }
+
+  // Initialize the compiler (thread-safe, first call wins).
+  // If compiler_lib_path is empty, auto-discovery finds the pip-installed
+  // or build-time-configured compiler library.
+  if (IreeCompiler::IsInitialized() && !compiler_lib_path.empty()) {
+    ORT_CXX_LOGF_NOEXCEPT(factory->logger_, ORT_LOGGING_LEVEL_WARNING,
+                          "IREE EP: Compiler already initialized; ignoring "
+                          "ep.iree.compiler_lib_path='%s' from this session. "
+                          "The compiler is process-global (first init wins).",
+                          compiler_lib_path.c_str());
+  }
+  {
+    OrtStatus* compiler_status = IreeCompiler::Initialize(compiler_lib_path);
+    if (compiler_status != nullptr) {
+      return compiler_status;
     }
   }
 

--- a/src/platform_utils.h
+++ b/src/platform_utils.h
@@ -1,0 +1,75 @@
+//===- platform_utils.h ---------------------------------------------------===//
+//
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Cross-platform utilities: environment variable access and self-library path
+// resolution. Used for compiler discovery logic.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ONNXRUNTIME_EP_IREE_SRC_PLATFORM_UTILS_H_
+#define ONNXRUNTIME_EP_IREE_SRC_PLATFORM_UTILS_H_
+
+#include <cstdlib>
+#include <string>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace onnxruntime::iree {
+
+// Get an environment variable value. Returns empty string if not set.
+inline std::string GetEnv(const char* name) {
+#if defined(_WIN32)
+  // MSVC deprecates getenv; use _dupenv_s.
+  char* value = nullptr;
+  size_t len = 0;
+  if (_dupenv_s(&value, &len, name) == 0 && value != nullptr) {
+    std::string result(value);
+    free(value);
+    return result;
+  }
+  return {};
+#else
+  const char* value = std::getenv(name);
+  return value ? std::string(value) : std::string{};
+#endif
+}
+
+// Get the filesystem path of the shared library containing this function.
+// Returns empty string on failure. Uses dladdr (POSIX) or GetModuleFileName
+// (Windows) on the function's own address to locate the enclosing library.
+inline std::string GetSelfLibraryPath() {
+#if defined(_WIN32)
+  HMODULE hm = NULL;
+  if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCSTR>(&GetSelfLibraryPath), &hm)) {
+    return {};
+  }
+  char path[MAX_PATH];
+  DWORD len = GetModuleFileNameA(hm, path, sizeof(path));
+  if (len == 0 || len >= sizeof(path)) {
+    return {};
+  }
+  return std::string(path, len);
+#else
+  Dl_info dl_info;
+  if (dladdr(reinterpret_cast<void*>(&GetSelfLibraryPath), &dl_info) == 0 ||
+      dl_info.dli_fname == nullptr) {
+    return {};
+  }
+  return dl_info.dli_fname;
+#endif
+}
+
+}  // namespace onnxruntime::iree
+
+#endif  // ONNXRUNTIME_EP_IREE_SRC_PLATFORM_UTILS_H_

--- a/src/plugin_entry.cc
+++ b/src/plugin_entry.cc
@@ -13,15 +13,25 @@
 #include "iree_ep_factory.h"
 #include "ort_import.h"
 
+// ORT_EXPORT is a no-op on Linux. Define EP_EXPORT with explicit visibility
+// so that only the plugin entry points are exported from the shared library.
+// Combined with CXX_VISIBILITY_PRESET=hidden in CMake, this ensures all
+// statically-linked IREE runtime symbols remain hidden.
+#if defined(_WIN32)
+#define EP_EXPORT __declspec(dllexport)
+#else
+#define EP_EXPORT __attribute__((visibility("default")))
+#endif
+
 extern "C" {
 
 // Plugin entry point - creates EP factories.
-ORT_EXPORT OrtStatus* CreateEpFactories(const char* registration_name,
-                                        const OrtApiBase* ort_api_base,
-                                        const OrtLogger* default_logger,
-                                        OrtEpFactory** factories,
-                                        size_t max_factories,
-                                        size_t* num_factories) {
+EP_EXPORT OrtStatus* CreateEpFactories(const char* registration_name,
+                                       const OrtApiBase* ort_api_base,
+                                       const OrtLogger* default_logger,
+                                       OrtEpFactory** factories,
+                                       size_t max_factories,
+                                       size_t* num_factories) {
   const OrtApi* ort_api = ort_api_base->GetApi(ORT_API_VERSION);
   const OrtEpApi* ep_api = ort_api->GetEpApi();
   const OrtModelEditorApi* model_editor_api = ort_api->GetModelEditorApi();
@@ -47,7 +57,7 @@ ORT_EXPORT OrtStatus* CreateEpFactories(const char* registration_name,
 }
 
 // Plugin cleanup
-ORT_EXPORT OrtStatus* ReleaseEpFactory(OrtEpFactory* factory) {
+EP_EXPORT OrtStatus* ReleaseEpFactory(OrtEpFactory* factory) {
   delete static_cast<onnxruntime::iree::IreeEpFactory*>(factory);
   return nullptr;
 }

--- a/src/symbols.lds
+++ b/src/symbols.lds
@@ -1,7 +1,0 @@
-{
-  global:
-    CreateEpFactories;
-    ReleaseEpFactory;
-  local:
-    *;
-};

--- a/src/symbols.txt
+++ b/src/symbols.txt
@@ -1,2 +1,0 @@
-_CreateEpFactories
-_ReleaseEpFactory

--- a/test/test_compiler_discovery.py
+++ b/test/test_compiler_discovery.py
@@ -1,0 +1,296 @@
+"""Tests for compiler library discovery (C++ runtime paths and env vars).
+
+Covers:
+  - Python get_library_path() for EP shared library
+  - C++ runtime env var override (IREE_EP_COMPILER_LIB / IREE_EP_COMPILER_LIB_DIR)
+  - Clear error on invalid compiler path
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+import onnxruntime_ep_iree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COMPILER_LIB_NAMES = [
+    "libIREECompiler.so",
+    "libIREECompiler.dylib",
+    "IREECompiler.dll",
+]
+
+
+def _find_compiler_lib_or_skip():
+    """Return path to the pip-installed compiler library, or skip."""
+    try:
+        import iree.compiler._mlir_libs as libs
+    except ImportError:
+        pytest.skip("iree-base-compiler not installed")
+
+    lib_dir = pathlib.Path(libs.__file__).parent
+    for name in _COMPILER_LIB_NAMES:
+        candidate = lib_dir / name
+        if candidate.exists():
+            return str(candidate.resolve())
+    pytest.skip("iree-base-compiler installed but compiler library not found")
+
+
+def _run_ep_subprocess(env_overrides):
+    """Run a subprocess that registers the EP and lists devices."""
+    env = os.environ.copy()
+    env.update(env_overrides)
+
+    script = """\
+import sys
+import onnxruntime as ort
+import onnxruntime_ep_iree
+
+ep_lib_path = onnxruntime_ep_iree.get_library_path()
+ort.register_execution_provider_library(
+    onnxruntime_ep_iree.get_ep_name(), ep_lib_path
+)
+
+devices = ort.get_ep_devices()
+iree_devices = [d for d in devices if d.device.metadata.get("iree.driver")]
+if iree_devices:
+    print("EP loaded successfully")
+    sys.exit(0)
+else:
+    print("No IREE devices found")
+    sys.exit(1)
+"""
+
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_library_path():
+    """get_library_path() finds the EP shared library."""
+    path = onnxruntime_ep_iree.get_library_path()
+    assert pathlib.Path(path).exists(), f"EP library not found at {path}"
+
+
+def test_env_var_compiler_lib_dir():
+    """IREE_EP_COMPILER_LIB_DIR env var directs compiler discovery."""
+    compiler_path = _find_compiler_lib_or_skip()
+    compiler_dir = str(pathlib.Path(compiler_path).parent)
+
+    result = _run_ep_subprocess({"IREE_EP_COMPILER_LIB_DIR": compiler_dir})
+    assert result.returncode == 0, (
+        f"EP failed with IREE_EP_COMPILER_LIB_DIR={compiler_dir}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_env_var_compiler_lib():
+    """IREE_EP_COMPILER_LIB env var provides full path to compiler library."""
+    compiler_path = _find_compiler_lib_or_skip()
+
+    result = _run_ep_subprocess({"IREE_EP_COMPILER_LIB": compiler_path})
+    assert result.returncode == 0, (
+        f"EP failed with IREE_EP_COMPILER_LIB={compiler_path}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_bad_compiler_path_error_message():
+    """Invalid compiler path produces a clear, diagnostic error message.
+
+    ORT falls back to CPU when the EP fails — it doesn't raise an exception.
+    We check that the error output contains the bad path and search order.
+    """
+    script = """\
+import sys
+import onnxruntime as ort
+import onnxruntime_ep_iree
+
+ep_lib_path = onnxruntime_ep_iree.get_library_path()
+ort.register_execution_provider_library(
+    onnxruntime_ep_iree.get_ep_name(), ep_lib_path
+)
+
+opts = ort.SessionOptions()
+opts.add_session_config_entry(
+    "ep.iree.compiler_lib_path", "/nonexistent/libIREECompiler.so"
+)
+
+from onnx import TensorProto, helper
+input_a = helper.make_tensor_value_info("A", TensorProto.FLOAT, [2, 2])
+output = helper.make_tensor_value_info("C", TensorProto.FLOAT, [2, 2])
+relu_node = helper.make_node("Relu", ["A"], ["C"])
+graph = helper.make_graph([relu_node], "test", [input_a], [output])
+model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+model.ir_version = 8
+
+import tempfile, os
+f = tempfile.NamedTemporaryFile(suffix=".onnx", delete=False)
+from onnx import save
+save(model, f.name)
+f.close()
+
+for dev in ort.get_ep_devices():
+    if dev.device.metadata.get("iree.driver") == "local-task":
+        opts.add_provider_for_devices([dev], {"target_arch": "host"})
+        break
+
+try:
+    session = ort.InferenceSession(f.name, sess_options=opts)
+finally:
+    os.unlink(f.name)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+    assert "/nonexistent/libIREECompiler.so" in combined, (
+        f"Error output should contain bad path.\nstdout: {result.stdout[:500]}\n"
+        f"stderr: {result.stderr[:500]}"
+    )
+    assert "Search order" in combined, (
+        f"Error output should contain search order listing.\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:500]}"
+    )
+    assert "session option" in combined, (
+        f"Error output should mention session option step.\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:500]}"
+    )
+
+
+def test_compiler_retry_after_bad_path():
+    """After a failed Initialize() with a bad path, a second call with a good
+    path in the same process succeeds — load failures are not cached.
+
+    Regression guard: if s_init_error caching were reintroduced, the second
+    session would re-emit the bad-path error and never use the compiler.
+    We detect this by asserting the bad path appears exactly once in output
+    (first attempt) and that inference via the second session is correct
+    (confirming the compiler initialized and the EP compiled the model).
+    """
+    compiler_path = _find_compiler_lib_or_skip()
+
+    script = f"""\
+import sys
+import onnxruntime as ort
+import onnxruntime_ep_iree
+import numpy as np
+
+ep_lib_path = onnxruntime_ep_iree.get_library_path()
+ort.register_execution_provider_library(
+    onnxruntime_ep_iree.get_ep_name(), ep_lib_path
+)
+
+local_task_dev = None
+for dev in ort.get_ep_devices():
+    if dev.device.metadata.get("iree.driver") == "local-task":
+        local_task_dev = dev
+        break
+if local_task_dev is None:
+    print("SKIP: no local-task device")
+    sys.exit(0)
+
+from onnx import TensorProto, helper, save
+import tempfile, os
+
+input_a = helper.make_tensor_value_info("A", TensorProto.FLOAT, [2, 2])
+output = helper.make_tensor_value_info("C", TensorProto.FLOAT, [2, 2])
+relu_node = helper.make_node("Relu", ["A"], ["C"])
+graph = helper.make_graph([relu_node], "test", [input_a], [output])
+model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+model.ir_version = 8
+
+f = tempfile.NamedTemporaryFile(suffix=".onnx", delete=False)
+save(model, f.name)
+f.close()
+
+try:
+    # Attempt 1: bad compiler path.  ORT falls back to CPU; error goes to
+    # stderr.  IreeCompiler::Initialize() fails but caches nothing.
+    opts_bad = ort.SessionOptions()
+    opts_bad.add_session_config_entry(
+        "ep.iree.compiler_lib_path", "/nonexistent/libIREECompiler.so"
+    )
+    opts_bad.add_provider_for_devices([local_task_dev], {{"target_arch": "host"}})
+    try:
+        ort.InferenceSession(f.name, sess_options=opts_bad)
+    except Exception:
+        pass  # ORT may raise or fall back silently.
+
+    # Attempt 2: good compiler path in the same process.  Must not be blocked
+    # by the previous failure.
+    opts_good = ort.SessionOptions()
+    opts_good.add_session_config_entry(
+        "ep.iree.compiler_lib_path", {compiler_path!r}
+    )
+    opts_good.add_provider_for_devices([local_task_dev], {{"target_arch": "host"}})
+    session = ort.InferenceSession(f.name, sess_options=opts_good)
+
+    # Print the providers used by the second session so the parent process can
+    # assert the IREE EP is active (not just CPU fallback).
+    print("PROVIDERS:" + ",".join(session.get_providers()), flush=True)
+
+    input_data = np.array([[1.0, -2.0], [-3.0, 4.0]], dtype=np.float32)
+    result = session.run(None, {{"A": input_data}})[0]
+    expected = np.maximum(0.0, input_data)
+    if not np.allclose(result, expected):
+        print(f"WRONG_RESULT: {{result}} vs {{expected}}", flush=True)
+        sys.exit(2)
+
+    print("RETRY_SUCCEEDED", flush=True)
+finally:
+    os.unlink(f.name)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    combined = result.stdout + result.stderr
+
+    if "SKIP:" in result.stdout:
+        pytest.skip("no local-task device available")
+
+    # Bad path must appear from attempt 1.
+    assert "/nonexistent/libIREECompiler.so" in combined, (
+        f"Expected bad-path error from attempt 1.\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:500]}"
+    )
+
+    # The IREE EP must be active in the second session — not just CPU fallback.
+    # If error caching regressed, Initialize() would return the cached bad-path
+    # error, the EP would fail, and ORT would fall back to CPU only.
+    providers_line = next(
+        (l for l in result.stdout.splitlines() if l.startswith("PROVIDERS:")), ""
+    )
+    assert "IREE" in providers_line, (
+        f"IREE EP not in second session providers — retry may have been blocked.\n"
+        f"providers: {providers_line}\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:500]}"
+    )
+
+    assert "RETRY_SUCCEEDED" in result.stdout, (
+        f"Second session with good path did not succeed.\n"
+        f"stdout: {result.stdout[:500]}\nstderr: {result.stderr[:500]}"
+    )


### PR DESCRIPTION
Switch from invoking iree-compile as a subprocess to dynamically loading libIREECompiler.so via the IREE compiler C API. The runtime stays statically linked; only the compiler is loaded at runtime via dlopen.

- Add 6-level compiler discovery chain: session option, env vars (IREE_EP_COMPILER_LIB, IREE_EP_COMPILER_LIB_DIR), build-time default, relative-to-EP search, bare dlopen fallback
- CMake auto-detects pip-installed compiler with Python3_FIND_VIRTUALENV, validates the library exists, supports IREE_EP_REQUIRE_COMPILER_LIB
- Replace .lds/.txt linker scripts with -fvisibility=hidden + EP_EXPORT
- Add cross-platform support (Windows GetModuleHandleExA, macOS -unexported_symbols_list)
- Thread-safe init via std::call_once with retry-on-failure semantics
- Add compiler discovery test suite
- Add get_compiler_library_path() Python helper