### PR TITLE
Rewrite .clang-tidy for project conventions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,61 +1,105 @@
----
+Checks: [
+        -*,
+        clang-diagnostic-*,
+        bugprone-*,
+        google-*,
+        misc-*,
+        modernize-*,
+        performance-*,
+        readability-*,
+        # --- Permanent suppressions ---
+        -bugprone-easily-swappable-parameters,  # EP interface-imposed signatures
+        -misc-include-cleaner,                  # transitive includes from ORT/IREE headers
+        -misc-non-private-member-variables-in-classes,  # ORT EP struct pattern
+        -modernize-use-trailing-return-type,
+        -readability-implicit-bool-conversion,  # idiomatic C pointer truthiness checks
+        -readability-identifier-length,
+        -readability-braces-around-statements,
+        -readability-convert-member-functions-to-static,  # ORT CRTP requires non-static
+        -readability-magic-numbers,
+        # --- TODO: Fix warnings and re-enable ---
+        -bugprone-macro-parentheses,            # add NOLINT to assign-or-return macros
+        -bugprone-exception-escape,             # noexcept functions with throwing paths
+        -bugprone-unhandled-exception-at-new,   # bare new in noexcept function
+        -performance-inefficient-vector-operation,
+        -misc-const-correctness,
+        -misc-use-anonymous-namespace,
+        -modernize-use-nodiscard,
+        -modernize-use-default-member-init,
+        -modernize-use-emplace,
+        -modernize-use-auto,
+        -modernize-avoid-c-arrays,
+        -modernize-use-ranges,
+        -modernize-loop-convert,
+        -modernize-pass-by-value,
+        -modernize-use-equals-default,
+        -modernize-use-transparent-functors,
+        -modernize-use-designated-initializers,
+        -readability-named-parameter,
+        -readability-function-cognitive-complexity,
+        -readability-container-contains,
+        -readability-redundant-string-init,
+        -readability-uppercase-literal-suffix,
+        -readability-redundant-casting,
+        -readability-qualified-auto,
+        -readability-math-missing-parentheses,
+        -readability-identifier-naming,
+        -google-readability-todo,
+        -google-explicit-constructor,
+]
 
-# NOTE:
-#     The check is a multiline string here. Comment must not be moved into the string.
-#     Be sure to keep the disabled rules alphabetically sorted.
-#
-# Based on https://github.com/microsoft/onnxruntime/tree/main
-#
-# Checks that are turned off:
-#
-# -cppcoreguidelines-macro-usage: There are a lot of false-positives like Function-like macro 'Foo' used; consider a 'constexpr' template function
-# -cppcoreguidelines-pro-type-reinterpret-cast: Originally turned off.
-# -google-readability-todo: Not enforced.
-# -google-runtime-references: https://github.com/microsoft/onnxruntime/blob/main/docs/Coding_Conventions_and_Standards.md#c-code-style.
-# -modernize-concat-nested-namespaces: We don't use it.
-# -modernize-use-trailing-return-type: Stylistic preference we do not enforce.
-# -readability-identifier-length: A lot of numerical code rely on short names to improve readability.
-# -readability-uppercase-literal-suffix: We accept lowercase suffixes
+HeaderFilterRegex: 'src/.*\.h$'
 
-Checks: >
-  -*,
-  cppcoreguidelines-*,
-  google-*,
-  readability-*,
-  modernize-*,
-  bugprone-*,
-  performance-*,
-  misc-*,
-  -cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-pro-type-reinterpret-cast,
-  -google-readability-todo,
-  -google-runtime-references,
-  -modernize-concat-nested-namespaces,
-  -modernize-use-trailing-return-type,
-  -readability-identifier-length,
-  -readability-uppercase-literal-suffix,
-WarningsAsErrors: ""
-AnalyzeTemporaryDtors: false
-FormatStyle: none
 CheckOptions:
-  - key: google-readability-braces-around-statements.ShortStatementLines
-    value: "1"
-  - key: google-readability-function-size.StatementThreshold
-    value: "800"
-  - key: google-readability-namespace-comments.ShortNamespaceLines
-    value: "10"
-  - key: google-readability-namespace-comments.SpacesBeforeComments
-    value: "2"
-  - key: modernize-loop-convert.MaxCopySize
-    value: "16"
-  - key: modernize-loop-convert.MinConfidence
-    value: reasonable
-  - key: modernize-loop-convert.NamingStyle
+  - key: readability-identifier-naming.ClassCase
     value: CamelCase
-  - key: modernize-pass-by-value.IncludeStyle
-    value: google
-  - key: modernize-replace-auto-ptr.IncludeStyle
-    value: google
-  - key: modernize-use-nullptr.NullMacros
-    value: "NULL"
----
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: CamelCase
+  - key: readability-identifier-naming.MethodCase
+    value: CamelCase
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: '_'
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: '_'
+  - key: readability-identifier-naming.PublicMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: k
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantPrefix
+    value: k
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalVariablePrefix
+    value: g_
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase
+  # Intentional exceptions: C callback self-pointer convention
+  - key: readability-identifier-naming.ParameterIgnoredRegexp
+    value: '^this_$'
+  # Intentional exceptions: LLVM-style lightweight predicates/factories
+  - key: readability-identifier-naming.FunctionIgnoredRegexp
+    value: '^(isOk|isError|error)$'
+  - key: readability-identifier-naming.MethodIgnoredRegexp
+    value: '^(getError|hasValue|assertHasValue)$'


### PR DESCRIPTION
The inherited ORT config was broken (AnalyzeTemporaryDtors parse error) and never enforced. Fixing the config by removing AnalyzeTemporaryDtors causes ~600 warnings/errors. Instead, this replaces the old config with a new one triaged against the actual codebase. Checks with existing warnings are TODO-suppressed for follow-up PRs.