### PR TITLE
Add better Python packaging and dev workflow

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -19,22 +19,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install system dependencies
-        run: brew install ninja
-
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
-
-      - name: CMake - configure
-        run: cmake -G Ninja -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
-
-      - name: CMake - build
-        run: cmake --build ${BUILD_DIR}
+        run: pip install -r requirements-dev.txt
 
       - name: Install Python package
-        run: |
-          ONNXRUNTIME_EP_IREE_BUILD_DIR=${{ github.workspace }}/${BUILD_DIR} \
-            pip install python/
+        run: pip install ./python
 
       - name: Run tests
         run: pytest test/ -v

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -22,18 +22,10 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt numpy
-
-      - name: CMake - configure
-        run: cmake -G Ninja -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
-
-      - name: CMake - build
-        run: cmake --build ${{ env.BUILD_DIR }}
+        run: pip install -r requirements-dev.txt
 
       - name: Install Python package
-        run: |
-          $env:ONNXRUNTIME_EP_IREE_BUILD_DIR = "${{ github.workspace }}\${{ env.BUILD_DIR }}"
-          pip install python/
+        run: pip install .\python
 
       - name: Run tests
         run: pytest test/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,22 +21,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
-
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
-
-      - name: CMake - configure
-        run: cmake -G Ninja -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
-
-      - name: CMake - build
-        run: cmake --build ${BUILD_DIR}
+        run: pip install -r requirements-dev.txt
 
       - name: Install Python package
-        run: |
-          ONNXRUNTIME_EP_IREE_BUILD_DIR=${{ github.workspace }}/${BUILD_DIR} \
-            pip install python/
+        run: pip install ./python
 
       - name: Run tests
         run: pytest test/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Build directories
 build/
+dist/
 cmake-build-*/
 
 # IDE and editor files
@@ -33,6 +34,7 @@ __pycache__/
 venv/
 .venv/
 env/
+.env/
 
 # Jupyter
 .ipynb_checkpoints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,12 @@ include(FetchContent)
 #
 ################################################################################
 
-set(ONNXRUNTIME_VERSION "1.24.1")
+set(
+  ONNXRUNTIME_VERSION
+  "1.24.1"
+  CACHE STRING
+  "ONNX Runtime version to fetch when ONNXRUNTIME_SOURCE_DIR is unset"
+)
 set(ONNXRUNTIME_SOURCE_DIR "" CACHE FILEPATH "Path to ONNX Runtime source")
 
 if(ONNXRUNTIME_SOURCE_DIR)

--- a/README.md
+++ b/README.md
@@ -2,32 +2,126 @@
 
 IREE based ONNX Runtime Execution Provider.
 
-## Installation
+## Basic Python Installation
 
-1. Build the plugin
+This path is recommended for Python users: install or wheel the Python package.
 
-```bash
-mkdir build && cd build
-cmake ..
-make -j
-```
-
-2. Create a virtual environment and install dependencies
+1. Create and activate a virtual environment
 
 ```bash
 python3 -m venv .env
 source .env/bin/activate
-pip install -r requirements.txt
 ```
 
-3. Install Python Package
+2. Build and install the Python package directly
 
 ```bash
-ONNXRUNTIME_EP_IREE_BUILD_DIR=$(pwd)/build uv pip install -e python/
+pip install ./python
 ```
 
-4. Run sample test
+This runs CMake as part of the package build and places the native build tree in
+`build/cmake/default` by default.
+
+Today this path only packages the default variant. The entrypoint is intended to
+grow a tracing variant later without changing the install command.
+
+To get the shared library path after installation, run:
+
+```bash
+python3 -c 'import onnxruntime_ep_iree; print(onnxruntime_ep_iree.get_library_path())'
+```
+
+Optional environment variables:
+
+```bash
+# For build configuration, e.g. Debug or Release. Default is Release.
+ONNXRUNTIME_EP_IREE_CMAKE_BUILD_TYPE=Debug
+
+# For local source checkouts instead of the pinned fetched sources.
+ONNXRUNTIME_SOURCE_DIR=/path/to/onnxruntime
+ONNXRUNTIME_VERSION=1.24.1
+
+# For local source checkouts instead of the pinned fetched sources.
+ONNXRUNTIME_EP_IREE_IREE_SOURCE_DIR=/path/to/iree
+```
+
+## Recommended Dev Setup
+
+For developers, we recommend using `dev_me.py` for editable installs and
+rebuilds.
+
+1. Create a virtual environment and install development dependencies
+
+```bash
+python3 -m venv .env
+source .env/bin/activate
+pip install -r requirements-dev.txt setuptools wheel
+```
+
+Tip: If using `uv`, seed `pip` into the environment so `dev_me.py` can pick it up:
+
+```bash
+uv venv --seed .env
+source .env/bin/activate
+uv pip install -r requirements-dev.txt setuptools wheel
+```
+
+2. Make sure `cmake` and `ninja` are available on your PATH
+
+3. Start from a fresh build directory when doing the initial setup or when
+   changing configure-time inputs
+
+```bash
+rm -rf build/
+```
+
+4. Run the dev helper
+
+```bash
+./dev_me.py
+```
+
+Pass `--onnxruntime=/path/to/onnxruntime` and/or `--iree=/path/to/iree`
+explicitly if you want local source checkouts. Otherwise the package build
+falls back to the pinned fetched sources.
+
+Useful overrides:
+
+```bash
+./dev_me.py --build-type=Debug
+./dev_me.py --onnxruntime=/path/to/onnxruntime --iree=/path/to/iree
+./dev_me.py --clang=/path/to/clang
+```
+
+Behavior:
+
+- On the first run, `dev_me.py` performs `pip install --no-build-isolation -e ./python`
+  and configures the package-owned build tree under `build/cmake/default`.
+- On later runs, `dev_me.py` performs incremental rebuilds of every configured
+  build directory under `build/cmake/`.
+- Delete `build/` to start over with a fresh configuration.
+
+Today this path only creates the default editable build. The rebuild path is
+already structured so future variants such as tracy will rebuild automatically
+once we add them.
+
+5. Run sample test
 
 ```bash
 python test/test_ep_load.py
 ```
+
+## Advanced Non-Python Usage
+
+If you only want the shared library and do not care about the Python package,
+build it directly with CMake:
+
+```bash
+cmake -S . -B build/native -G Ninja -DCMAKE_BUILD_TYPE=Release \
+  -DONNXRUNTIME_SOURCE_DIR=/path/to/onnxruntime \
+  -DIREE_SOURCE_DIR=/path/to/iree
+cmake --build build/native
+```
+
+If `ONNXRUNTIME_SOURCE_DIR` or `IREE_SOURCE_DIR` are omitted, CMake will fetch
+the pinned source dependencies instead.

--- a/dev_me.py
+++ b/dev_me.py
@@ -37,7 +37,9 @@ import sys
 
 CMAKE_REQUIRED_VERSION = (3, 24)
 PYTHON_REQUIRED_VERSION = (3, 10)
-SETUPTOOLS_REQUIRED_VERSION = (64, 0)
+SETUPTOOLS_REQUIRED_VERSION = (77, 0)
+
+DEFAULT_BUILD_TYPE = "RelWithDebInfo"
 
 
 def parse_version_components(version_text: str) -> tuple[int, ...]:
@@ -235,13 +237,13 @@ class EnvInfo:
 
 def has_configure_overrides(args: argparse.Namespace) -> bool:
     return any(
-        [
+        (
             args.cmake is not None,
             args.clang is not None,
             args.onnxruntime is not None,
             args.iree is not None,
-            args.build_type != "Debug",
-        ]
+            args.build_type != DEFAULT_BUILD_TYPE,
+        )
     )
 
 
@@ -334,8 +336,8 @@ def main(argv: list[str]) -> None:
     parser.add_argument("--iree", type=Path, help="Path to an IREE source checkout")
     parser.add_argument(
         "--build-type",
-        default="RelWithDebInfo",
-        help="CMake build type (default: RelWithDebInfo)",
+        default=DEFAULT_BUILD_TYPE,
+        help=f"CMake build type (default: {DEFAULT_BUILD_TYPE})",
     )
     args = parser.parse_args(argv)
 

--- a/dev_me.py
+++ b/dev_me.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Opinionated developer setup helper for onnxruntime-ep-iree.
+
+First-time usage:
+  rm -rf build
+  python dev_me.py [--cmake=/path/to/cmake] [--clang=/path/to/clang] \
+    [--onnxruntime=/path/to/onnxruntime] [--iree=/path/to/iree] \
+    [--build-type=Debug]
+
+Subsequent usage:
+  python dev_me.py
+
+This configures an editable install of the Python package into the active
+Python environment using the package-owned build directory under
+``build/cmake/default``. If one or more configured build directories already
+exist under ``build/cmake/``, rerunning this script performs incremental
+rebuilds instead of reconfiguring.
+
+Today the Python packaging flow only builds the default variant. The rebuild
+path intentionally discovers every configured directory under ``build/cmake/``
+so future variants such as tracy can be added without changing the developer
+workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from importlib import metadata
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+
+
+CMAKE_REQUIRED_VERSION = (3, 24)
+PYTHON_REQUIRED_VERSION = (3, 10)
+SETUPTOOLS_REQUIRED_VERSION = (64, 0)
+
+
+def parse_version_components(version_text: str) -> tuple[int, ...]:
+    matches = re.findall(r"\d+", version_text)
+    return tuple(int(match) for match in matches[:3])
+
+
+def format_version(version: tuple[int, ...] | None) -> str:
+    if not version:
+        return "not found"
+    return ".".join(str(part) for part in version)
+
+
+def quote_command(parts: list[str]) -> str:
+    import shlex
+
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+class EnvInfo:
+    def __init__(self, args: argparse.Namespace):
+        self.this_dir = Path(__file__).resolve().parent
+        self.python_exe = sys.executable
+        self.python_version = sys.version_info[:3]
+        self.has_pip_module = importlib.util.find_spec("pip") is not None
+        self.cmake_exe, self.cmake_version = self.find_cmake(args.cmake)
+        self.ninja_exe = shutil.which("ninja")
+        self.clang_exe, self.clangxx_exe = self.find_clang_pair(args.clang)
+        self.onnxruntime_dir = self.find_onnxruntime(args.onnxruntime)
+        self.iree_dir = self.find_iree(args.iree)
+        self.setuptools_version = self.find_package_version("setuptools")
+        self.wheel_version = self.find_package_version("wheel")
+        self.configured_dirs = self.find_configured_dirs()
+
+    def find_cmake(
+        self, cmake_path: Path | None
+    ) -> tuple[str | None, tuple[int, ...] | None]:
+        candidates = [str(cmake_path)] if cmake_path else []
+        if not candidates:
+            default_cmake = shutil.which("cmake")
+            if default_cmake:
+                candidates.append(default_cmake)
+        for candidate in candidates:
+            try:
+                output = subprocess.check_output(
+                    [candidate, "--version"], stderr=subprocess.STDOUT, text=True
+                )
+            except (OSError, subprocess.CalledProcessError):
+                continue
+            match = re.search(r"cmake version ([^\s]+)", output)
+            if match:
+                return candidate, parse_version_components(match.group(1))
+        return None, None
+
+    def find_clang_pair(self, clang_path: Path | None) -> tuple[str | None, str | None]:
+        if not clang_path:
+            return None, None
+        clang = Path(clang_path).resolve()
+        if not clang.exists():
+            print(f"ERROR: clang executable not found: {clang}")
+            sys.exit(1)
+        clangxx = clang.with_name("clang++")
+        if not clangxx.exists():
+            print(f"ERROR: matching clang++ executable not found next to {clang}")
+            sys.exit(1)
+        return str(clang), str(clangxx)
+
+    def find_onnxruntime(self, onnxruntime_dir: Path | None) -> str | None:
+        if onnxruntime_dir is None:
+            return None
+
+        candidate = onnxruntime_dir.resolve()
+        header = (
+            candidate
+            / "include"
+            / "onnxruntime"
+            / "core"
+            / "session"
+            / "onnxruntime_c_api.h"
+        )
+        if not header.exists():
+            print(
+                "ERROR: --onnxruntime must point to an ONNX Runtime source tree "
+                f"containing {header.relative_to(candidate)}"
+            )
+            sys.exit(1)
+        return str(candidate)
+
+    def find_iree(self, iree_dir: Path | None) -> str | None:
+        if iree_dir is None:
+            return None
+
+        candidate = iree_dir.resolve()
+        if not (candidate / "CMakeLists.txt").exists():
+            print("ERROR: --iree must point to an IREE source tree")
+            sys.exit(1)
+        return str(candidate)
+
+    def find_package_version(self, package_name: str) -> tuple[int, ...] | None:
+        try:
+            version = metadata.version(package_name)
+        except metadata.PackageNotFoundError:
+            return None
+        return parse_version_components(version)
+
+    def find_configured_dirs(self) -> list[Path]:
+        build_root = self.this_dir / "build" / "cmake"
+        if not build_root.exists():
+            return []
+        return sorted(
+            path
+            for path in build_root.iterdir()
+            if path.is_dir() and (path / "CMakeCache.txt").exists()
+        )
+
+    def has_live_build_tool(self, build_dir: Path) -> bool:
+        cache_file = build_dir / "CMakeCache.txt"
+        if not cache_file.exists():
+            return False
+        for line in cache_file.read_text().splitlines():
+            if line.startswith("CMAKE_MAKE_PROGRAM:"):
+                build_tool = line.split("=", 1)[1]
+                return bool(build_tool) and Path(build_tool).exists()
+        return True
+
+    def check_build_prereqs(self) -> None:
+        if self.python_version < PYTHON_REQUIRED_VERSION:
+            print(f"ERROR: python version too old: {self.python_exe}")
+            print(
+                f"  Required: {format_version(PYTHON_REQUIRED_VERSION)}, "
+                f"Found: {format_version(self.python_version)}"
+            )
+            sys.exit(1)
+
+        if self.cmake_version is None or self.cmake_version < CMAKE_REQUIRED_VERSION:
+            print(f"ERROR: cmake not found or version too old: {self.cmake_exe}")
+            print(
+                f"  Required: {format_version(CMAKE_REQUIRED_VERSION)}, "
+                f"Found: {format_version(self.cmake_version)}"
+            )
+            sys.exit(1)
+
+    def check_configure_prereqs(self) -> None:
+        self.check_build_prereqs()
+
+        if not self.ninja_exe:
+            print("ERROR: ninja not found on PATH")
+            sys.exit(1)
+
+        if (
+            self.setuptools_version is None
+            or self.setuptools_version < SETUPTOOLS_REQUIRED_VERSION
+        ):
+            print(
+                "ERROR: setuptools is not installed or too old for editable builds. "
+                f"Found {format_version(self.setuptools_version)}, "
+                f"need at least {format_version(SETUPTOOLS_REQUIRED_VERSION)}"
+            )
+            sys.exit(1)
+
+        if self.wheel_version is None:
+            print("ERROR: wheel is not installed")
+            sys.exit(1)
+
+        if not self.has_pip_module:
+            print(
+                "ERROR: pip is not available in the active Python environment. "
+                "If you are using uv, create the environment with `uv venv --seed`."
+            )
+            sys.exit(1)
+
+    def __repr__(self) -> str:
+        lines = [
+            f"python: {self.python_exe} ({format_version(self.python_version)})",
+            f"cmake: {self.cmake_exe} ({format_version(self.cmake_version)})",
+            f"ninja: {self.ninja_exe or 'not found'}",
+            f"clang: {self.clang_exe or 'system default'}",
+            f"onnxruntime: {self.onnxruntime_dir or 'pinned fetch'}",
+            f"iree: {self.iree_dir or 'pinned fetch'}",
+            f"setuptools: {format_version(self.setuptools_version)}",
+            f"wheel: {format_version(self.wheel_version)}",
+        ]
+        if self.configured_dirs:
+            lines.append(
+                "configured build dirs: "
+                + ", ".join(
+                    str(path.relative_to(self.this_dir))
+                    for path in self.configured_dirs
+                )
+            )
+        else:
+            lines.append("configured build dirs: none")
+        return "\n".join(lines)
+
+
+def has_configure_overrides(args: argparse.Namespace) -> bool:
+    return any(
+        [
+            args.cmake is not None,
+            args.clang is not None,
+            args.onnxruntime is not None,
+            args.iree is not None,
+            args.build_type != "Debug",
+        ]
+    )
+
+
+def configure_mode(env_info: EnvInfo, args: argparse.Namespace) -> None:
+    print("Environment info:")
+    print(env_info)
+    env_info.check_configure_prereqs()
+
+    env_vars = {
+        "ONNXRUNTIME_EP_IREE_CMAKE": env_info.cmake_exe,
+        "ONNXRUNTIME_EP_IREE_CMAKE_BUILD_TYPE": args.build_type,
+    }
+    if env_info.onnxruntime_dir:
+        env_vars["ONNXRUNTIME_SOURCE_DIR"] = env_info.onnxruntime_dir
+    if env_info.iree_dir:
+        env_vars["ONNXRUNTIME_EP_IREE_IREE_SOURCE_DIR"] = env_info.iree_dir
+    if env_info.clang_exe and env_info.clangxx_exe:
+        env_vars["ONNXRUNTIME_EP_IREE_C_COMPILER"] = env_info.clang_exe
+        env_vars["ONNXRUNTIME_EP_IREE_CXX_COMPILER"] = env_info.clangxx_exe
+
+    setup_cmd = [
+        env_info.python_exe,
+        "-m",
+        "pip",
+        "install",
+        # Reuse the active environment's build tooling instead of spinning up a
+        # temporary isolated env. That keeps editable installs fast and ensures
+        # rerunning dev_me.py rebuilds against the same cmake/ninja toolchain.
+        "--no-build-isolation",
+        "-v",
+        "-e",
+        str(env_info.this_dir / "python"),
+    ]
+
+    print("Executing setup:")
+    for key, value in env_vars.items():
+        print(f"  {key}={value}")
+    print(f"  {quote_command(setup_cmd)}")
+
+    actual_env = dict(os.environ)
+    actual_env.update(env_vars)
+    subprocess.check_call(setup_cmd, cwd=env_info.this_dir, env=actual_env)
+
+
+def build_mode(env_info: EnvInfo, args: argparse.Namespace) -> None:
+    env_info.check_build_prereqs()
+
+    if has_configure_overrides(args):
+        print(
+            "NOTE: build/cmake is already configured; configure-time flags are being "
+            "ignored. Delete build/ to reconfigure from scratch."
+        )
+
+    stale_dirs = [
+        build_dir
+        for build_dir in env_info.configured_dirs
+        if not env_info.has_live_build_tool(build_dir)
+    ]
+    if stale_dirs:
+        # The most common failure here is an old Ninja path cached from a prior
+        # pip build environment. Re-running the editable install refreshes the
+        # CMake cache using the current tool locations.
+        print(
+            "Detected stale build-tool paths in the existing CMake cache. "
+            "Refreshing the editable install to reconfigure the build tree."
+        )
+        configure_mode(env_info, args)
+        return
+
+    # Rebuild every configured variant under build/cmake/. Today that is just
+    # "default", but keeping the loop means future variants like "tracy" slot
+    # into the developer workflow without changing this entrypoint.
+    for build_dir in env_info.configured_dirs:
+        print(f"Building {build_dir.relative_to(env_info.this_dir)}")
+        subprocess.check_call(
+            [env_info.cmake_exe, "--build", str(build_dir)],
+            cwd=env_info.this_dir,
+        )
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(
+        prog="onnxruntime-ep-iree dev", description="Development setup helper"
+    )
+    parser.add_argument("--cmake", type=Path, help="Path to cmake")
+    parser.add_argument("--clang", type=Path, help="Path to clang")
+    parser.add_argument(
+        "--onnxruntime", type=Path, help="Path to an ONNX Runtime source checkout"
+    )
+    parser.add_argument("--iree", type=Path, help="Path to an IREE source checkout")
+    parser.add_argument(
+        "--build-type",
+        default="RelWithDebInfo",
+        help="CMake build type (default: RelWithDebInfo)",
+    )
+    args = parser.parse_args(argv)
+
+    env_info = EnvInfo(args)
+    if env_info.configured_dirs:
+        build_mode(env_info, args)
+    else:
+        configure_mode(env_info, args)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib

--- a/python/onnxruntime_ep_iree/__init__.py
+++ b/python/onnxruntime_ep_iree/__init__.py
@@ -32,32 +32,32 @@ def get_library_path() -> str:
     """Return the absolute path to the native IREE EP shared library.
 
     Lookup order:
-      1. The project's ``build/`` directory, found by walking up from this package's
-         location (``python/onnxruntime_ep_iree/ -> python/ -> project_root/ -> build/``).
-         This is the primary path for editable installs — it always points to the
-         latest build output, even after the C++ library is rebuilt.
+      1. The packaging build directory (``<project_root>/build/cmake/default``),
+         which is where ``pip install`` / ``pip wheel`` builds the shared library.
       2. The package directory itself (for wheel-based installs where the library
          was bundled into the package).
 
     Raises ``FileNotFoundError`` if the library cannot be found in either location.
     """
     pkg_dir = Path(__file__).parent
-
-    # 1. Check the project build directory (editable installs).
-    #    Layout: <project_root>/python/onnxruntime_ep_iree/__init__.py
     project_root = pkg_dir.parent.parent
-    result = _find_lib_in(project_root / "build")
+
+    # Editable installs import Python from the source tree, so the native EP is
+    # resolved from the packaging-owned build tree instead of site-packages.
+    result = _find_lib_in(project_root / "build" / "cmake" / "default")
     if result:
         return result
 
-    # 2. Check the package directory (wheel installs).
+    # Wheel installs bundle the shared library directly into the package.
     result = _find_lib_in(pkg_dir)
     if result:
         return result
 
     raise FileNotFoundError(
         "IREE EP library not found. "
-        "Make sure the C++ library has been built (cmake -B build -GNinja && ninja -C build)."
+        "Build the package with `pip install ./python` or "
+        "`pip wheel -w dist ./python`. For editable installs, build the native library in "
+        "`build/cmake/default`."
     )
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "cmake>=3.24",
+    "setuptools>=77",
+    "wheel",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,68 +1,154 @@
-"""Setup script for the onnxruntime-ep-iree Python package.
-
-Currently, we use ONNXRUNTIME_EP_IREE_BUILD_DIR to specify the build directory used by
-the developer to built the library. The library is built externally via cmake
-and not by this setup script. It is only required at install time, not at
-runtime. For editable installs, setup.py only validates the setup.py exists in
-the build directory, it doesn't copy or generate any files. At runtime,
-``get_library_path()`` finds the library by walking up from the package's
-source location to ``<project_root>/build/``. This means rebuilds are picked up
-immediately without reinstalling. For wheel builds (``pip wheel`` / ``pip
-install``), setup.py copies the library into the package directory so it is
-bundled in the wheel.
-
-Note that this is a very temporary setup. We are never going to ship like this.
-The only reason we started out like this is because before this we were hardcoding
-library paths, which didn't work when trying to develop the library on macos
-vs linux (.dylib vs .so). We will eventually probably do something similar to
-shortfin, where we have a devme.py file to get things setup for dev workflow,
-and let the setup.py build a normal build and a tracy enabled build.
-"""
-
 import os
 import pathlib
 import shutil
+import subprocess
+import sys
+import traceback
 
 from setuptools import Distribution, setup
+from setuptools.command.build_py import build_py as _build_py
 
-script_dir = pathlib.Path(__file__).parent.resolve()
 
-# ---------------------------------------------------------------------------
-# Locate the pre-built native library via environment variable.
-# ---------------------------------------------------------------------------
-build_dir = os.environ.get("ONNXRUNTIME_EP_IREE_BUILD_DIR")
-if not build_dir:
-    raise EnvironmentError(
-        "ONNXRUNTIME_EP_IREE_BUILD_DIR environment variable must be set to the "
-        "directory containing the built libonnxruntime_ep_iree shared library."
-    )
-
-build_dir = pathlib.Path(build_dir).resolve()
-
-# Find the library in the build directory.
-lib_names = [
+SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
+SOURCE_DIR = SCRIPT_DIR.parent
+# Keep packaging-owned builds in a single stable location so editable installs,
+# wheel builds, and runtime library lookup all agree on where the native
+# artifact lives.
+DEFAULT_BUILD_DIR = SOURCE_DIR / "build" / "cmake" / "default"
+CMAKE_EXE = os.environ.get("ONNXRUNTIME_EP_IREE_CMAKE", "cmake")
+LIB_NAMES = [
     "libonnxruntime_ep_iree.dylib",
     "libonnxruntime_ep_iree.so",
     "onnxruntime_ep_iree.dll",
 ]
-found = [build_dir / name for name in lib_names if (build_dir / name).exists()]
-if len(found) != 1:
-    raise FileNotFoundError(
-        f"Expected exactly one EP library in {build_dir}, "
-        f"found: {[str(p) for p in found]}"
-    )
-ep_lib_path = found[0]
 
-# ---------------------------------------------------------------------------
-# For non-editable installs, copy the library into the package so it gets
-# bundled into the wheel.  For editable installs this copy is unnecessary
-# (get_library_path() finds it via relative path), but it's harmless and
-# keeps setup.py simple — no need to detect which install mode we're in.
-# ---------------------------------------------------------------------------
-pkg_dir = script_dir / "onnxruntime_ep_iree"
-dst = pkg_dir / ep_lib_path.name
-if dst.resolve() != ep_lib_path.resolve():
-    shutil.copyfile(ep_lib_path, dst)
+
+def add_env_cmake_setting(
+    args: list[str], env_name: str, cmake_name: str | None = None
+):
+    value = os.getenv(env_name)
+    if value:
+        args.append(f"-D{cmake_name or env_name}={value}")
+
+
+def maybe_nuke_cmake_cache(build_dir: pathlib.Path) -> str:
+    ninja_path = shutil.which("ninja") or ""
+    # PEP 517/660 builds can run under different virtualenvs or isolated build
+    # environments across invocations. CMake caches both the Python executable
+    # and the Ninja path, so preserve a tiny stamp and invalidate the cache when
+    # either one changes underneath an existing build tree.
+    expected_stamp = f"{sys.executable}\n{ninja_path}"
+    stamp_file = build_dir / "python_stamp.txt"
+    if stamp_file.exists() and stamp_file.read_text() == expected_stamp:
+        return ninja_path
+
+    cmake_cache = build_dir / "CMakeCache.txt"
+    if cmake_cache.exists():
+        cmake_cache.unlink()
+
+    stamp_file.write_text(expected_stamp)
+    return ninja_path
+
+
+def find_library(root_dir: pathlib.Path) -> pathlib.Path:
+    candidates = []
+    # CMake install layouts differ slightly across platforms and generators, so
+    # search the common staging locations and require a single unambiguous EP
+    # library before packaging it.
+    for directory in [
+        root_dir,
+        root_dir / "lib",
+        root_dir / "bin",
+        root_dir / "Release",
+        root_dir / "Debug",
+    ]:
+        for lib_name in LIB_NAMES:
+            lib_path = directory / lib_name
+            if lib_path.exists():
+                candidates.append(lib_path)
+    unique_candidates = sorted(set(candidates), key=str)
+    if len(unique_candidates) != 1:
+        raise FileNotFoundError(
+            f"Expected exactly one EP library under {root_dir}, "
+            f"found: {[str(path) for path in unique_candidates]}"
+        )
+    return unique_candidates[0]
+
+
+def build_native_extension() -> pathlib.Path:
+    build_dir = DEFAULT_BUILD_DIR.resolve()
+    stage_dir = build_dir / "python-install"
+    build_type = os.environ.get("ONNXRUNTIME_EP_IREE_CMAKE_BUILD_TYPE", "Release")
+    generator = os.environ.get("CMAKE_GENERATOR", "Ninja")
+    build_dir.mkdir(parents=True, exist_ok=True)
+    ninja_path = maybe_nuke_cmake_cache(build_dir)
+
+    cmake_args = [
+        "-S",
+        str(SOURCE_DIR),
+        "-B",
+        str(build_dir),
+        "-G",
+        generator,
+        f"-DCMAKE_BUILD_TYPE={build_type}",
+        # Pass both spellings because the top-level project and fetched
+        # dependencies may use different FindPython modules.
+        f"-DPython_EXECUTABLE={sys.executable}",
+        f"-DPython3_EXECUTABLE={sys.executable}",
+    ]
+    if generator.startswith("Ninja") and ninja_path:
+        cmake_args.append(f"-DCMAKE_MAKE_PROGRAM={ninja_path}")
+    add_env_cmake_setting(cmake_args, "ONNXRUNTIME_SOURCE_DIR")
+    add_env_cmake_setting(cmake_args, "ONNXRUNTIME_VERSION")
+    add_env_cmake_setting(
+        cmake_args, "ONNXRUNTIME_EP_IREE_IREE_SOURCE_DIR", "IREE_SOURCE_DIR"
+    )
+    add_env_cmake_setting(
+        cmake_args, "ONNXRUNTIME_EP_IREE_C_COMPILER", "CMAKE_C_COMPILER"
+    )
+    add_env_cmake_setting(
+        cmake_args, "ONNXRUNTIME_EP_IREE_CXX_COMPILER", "CMAKE_CXX_COMPILER"
+    )
+
+    subprocess.check_call([CMAKE_EXE] + cmake_args)
+    subprocess.check_call(
+        [CMAKE_EXE, "--build", str(build_dir), "--config", build_type]
+    )
+    subprocess.check_call(
+        [
+            CMAKE_EXE,
+            "--install",
+            str(build_dir),
+            "--config",
+            build_type,
+            "--prefix",
+            str(stage_dir),
+        ]
+    )
+    return find_library(stage_dir)
+
+
+class CMakeBuildPy(_build_py):
+    def run(self):
+        super().run()
+        try:
+            built_library = build_native_extension()
+        except subprocess.CalledProcessError:
+            # Editable installs route through setuptools, which otherwise tends
+            # to collapse native build failures into a generic packaging error.
+            # Keep the underlying traceback visible and fail the install
+            # immediately.
+            print("Native build failed:")
+            traceback.print_exc()
+            sys.exit(1)
+        target_dir = pathlib.Path(self.build_lib) / "onnxruntime_ep_iree"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        # Wheels should contain exactly the freshly staged EP library and not a
+        # leftover artifact from a previous platform or build configuration.
+        for pattern in ("*.so", "*.dylib", "*.dll"):
+            for candidate in target_dir.glob(pattern):
+                candidate.unlink()
+        shutil.copyfile(built_library, target_dir / built_library.name)
 
 
 # ---------------------------------------------------------------------------
@@ -82,12 +168,20 @@ setup(
     version="0.1.0",
     description="Python helpers for the IREE ONNX Runtime Execution Provider",
     packages=["onnxruntime_ep_iree"],
-    # Includes ``*.dylib``, ``*.so``, ``*.dll`` so that when the library IS copied
-    # for wheel builds, it ends up in the installed package.
-    package_data={
-        "onnxruntime_ep_iree": ["*.dylib", "*.so", "*.dll"],
+    cmdclass={
+        "build_py": CMakeBuildPy,
     },
-    include_package_data=True,
+    # Include only the packaged EP shared library so stale local artifacts do
+    # not leak into wheels.
+    package_data={
+        "onnxruntime_ep_iree": [
+            "libonnxruntime_ep_iree.dylib",
+            "libonnxruntime_ep_iree.so",
+            "onnxruntime_ep_iree.dll",
+        ],
+    },
+    include_package_data=False,
     distclass=BinaryDistribution,
     python_requires=">=3.10",
+    zip_safe=False,
 )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 iree-base-compiler==3.10.0
 onnx==1.20.0
 onnxruntime==1.24.1
-matplotlib
 numpy
 pytest


### PR DESCRIPTION
Removes the old dev workflow python packaging and adds proper python packaging that can build wheels.

Switches the recommended dev workflow to using a dev_me.py script that creates an editable pip install, manages different builds and simplifies multiple cmake flags.

Update the CI to use the new python package.