### PR TITLE
Add tracy variant support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,11 @@ endif()
 # runtime at this source ref.
 set(IREE_GIT_TAG "v3.10.0")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
+option(
+  ONNXRUNTIME_EP_IREE_ENABLE_TRACING
+  "Enable IREE runtime tracing and fetch Tracy when needed"
+  OFF
+)
 
 # Set IREE build flags.
 set(IREE_VISIBILITY_HIDDEN ON)
@@ -103,6 +108,16 @@ if(NOT APPLE)
   set(IREE_HAL_DRIVER_VULKAN ON)
 endif()
 
+if(ONNXRUNTIME_EP_IREE_ENABLE_TRACING)
+  set(IREE_ENABLE_RUNTIME_TRACING ON)
+  # Shared-library builds can emit Tracy events before Tracy itself is fully
+  # initialized. Use the same delayed-init workaround that shortfin applies.
+  set(TRACY_DELAYED_INIT ON CACHE BOOL "Enable delayed init for tracy")
+  # The EP is loaded and unloaded as a plugin, so it must explicitly own
+  # Tracy startup/shutdown instead of relying on process-lifetime teardown.
+  set(TRACY_MANUAL_LIFETIME ON CACHE BOOL "Enable manual lifetime for tracy")
+endif()
+
 if(IREE_SOURCE_DIR)
   message(STATUS "Using existing IREE sources: ${IREE_SOURCE_DIR}")
   # Normalize so downstream code can use iree_SOURCE_DIR unconditionally
@@ -120,6 +135,9 @@ else()
   # Add vulkan_headers submodule only if Vulkan driver is enabled.
   if(IREE_HAL_DRIVER_VULKAN)
     list(APPEND IREE_SUBMODULES "third_party/vulkan_headers")
+  endif()
+  if(ONNXRUNTIME_EP_IREE_ENABLE_TRACING)
+    list(APPEND IREE_SUBMODULES "third_party/tracy")
   endif()
   FetchContent_Declare(
     iree
@@ -304,6 +322,7 @@ message(STATUS "IREE ONNX Execution Provider Configuration")
 message(STATUS "========================================")
 message(STATUS "  C++ Standard:        ${CMAKE_CXX_STANDARD}")
 message(STATUS "  Build Type:          ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Tracy Enabled:       ${ONNXRUNTIME_EP_IREE_ENABLE_TRACING}")
 message(STATUS "  ONNX Runtime Source: ${IREE_EP_ONNX_SRC_DIR}")
 message(STATUS "  IREE Source:         ${IREE_SOURCE_DIR}")
 message(STATUS "  Install Prefix:      ${CMAKE_INSTALL_PREFIX}")

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ pip install ./python
 This runs CMake as part of the package build and places the native build tree in
 `build/cmake/default` by default.
 
-Today this path only packages the default variant. The entrypoint is intended to
-grow a tracing variant later without changing the install command.
+Set `ONNXRUNTIME_EP_IREE_ENABLE_TRACING=ON` to also build and package the Tracy
+variant alongside the default one. Select the runtime in Python with
+`ONNXRUNTIME_EP_IREE_PY_RUNTIME=default` or `tracy`.
 
 To get the shared library path after installation, run:
 
@@ -96,14 +97,13 @@ Useful overrides:
 Behavior:
 
 - On the first run, `dev_me.py` performs `pip install --no-build-isolation -e ./python`
-  and configures the package-owned build tree under `build/cmake/default`.
+  and configures the package-owned build tree under `build/cmake/default`, and
+  also `build/cmake/tracy` unless `--no-tracing` is passed.
 - On later runs, `dev_me.py` performs incremental rebuilds of every configured
   build directory under `build/cmake/`.
 - Delete `build/` to start over with a fresh configuration.
-
-Today this path only creates the default editable build. The rebuild path is
-already structured so future variants such as tracy will rebuild automatically
-once we add them.
+- Select the Tracy-enabled editable runtime with
+  `ONNXRUNTIME_EP_IREE_PY_RUNTIME=tracy`.
 
 5. Run sample test
 

--- a/dev_me.py
+++ b/dev_me.py
@@ -5,21 +5,17 @@ First-time usage:
   rm -rf build
   python dev_me.py [--cmake=/path/to/cmake] [--clang=/path/to/clang] \
     [--onnxruntime=/path/to/onnxruntime] [--iree=/path/to/iree] \
-    [--build-type=Debug]
+    [--build-type=Debug] [--no-tracing]
 
 Subsequent usage:
   python dev_me.py
 
 This configures an editable install of the Python package into the active
 Python environment using the package-owned build directory under
-``build/cmake/default``. If one or more configured build directories already
-exist under ``build/cmake/``, rerunning this script performs incremental
-rebuilds instead of reconfiguring.
-
-Today the Python packaging flow only builds the default variant. The rebuild
-path intentionally discovers every configured directory under ``build/cmake/``
-so future variants such as tracy can be added without changing the developer
-workflow.
+``build/cmake/default`` and, by default, also under ``build/cmake/tracy``.
+If one or more configured build directories already exist under
+``build/cmake/``, rerunning this script performs incremental rebuilds instead
+of reconfiguring.
 """
 
 from __future__ import annotations
@@ -242,6 +238,7 @@ def has_configure_overrides(args: argparse.Namespace) -> bool:
             args.clang is not None,
             args.onnxruntime is not None,
             args.iree is not None,
+            args.no_tracing,
             args.build_type != DEFAULT_BUILD_TYPE,
         )
     )
@@ -255,6 +252,7 @@ def configure_mode(env_info: EnvInfo, args: argparse.Namespace) -> None:
     env_vars = {
         "ONNXRUNTIME_EP_IREE_CMAKE": env_info.cmake_exe,
         "ONNXRUNTIME_EP_IREE_CMAKE_BUILD_TYPE": args.build_type,
+        "ONNXRUNTIME_EP_IREE_ENABLE_TRACING": "OFF" if args.no_tracing else "ON",
     }
     if env_info.onnxruntime_dir:
         env_vars["ONNXRUNTIME_SOURCE_DIR"] = env_info.onnxruntime_dir
@@ -313,9 +311,7 @@ def build_mode(env_info: EnvInfo, args: argparse.Namespace) -> None:
         configure_mode(env_info, args)
         return
 
-    # Rebuild every configured variant under build/cmake/. Today that is just
-    # "default", but keeping the loop means future variants like "tracy" slot
-    # into the developer workflow without changing this entrypoint.
+    # Rebuild every configured variant under build/cmake/.
     for build_dir in env_info.configured_dirs:
         print(f"Building {build_dir.relative_to(env_info.this_dir)}")
         subprocess.check_call(
@@ -338,6 +334,11 @@ def main(argv: list[str]) -> None:
         "--build-type",
         default=DEFAULT_BUILD_TYPE,
         help=f"CMake build type (default: {DEFAULT_BUILD_TYPE})",
+    )
+    parser.add_argument(
+        "--no-tracing",
+        action="store_true",
+        help="Disable the Tracy package variant during initial configure",
     )
     args = parser.parse_args(argv)
 

--- a/python/onnxruntime_ep_iree/__init__.py
+++ b/python/onnxruntime_ep_iree/__init__.py
@@ -3,7 +3,13 @@
 Provides functions to locate the native EP shared library and its registration name.
 """
 
+import importlib
+import os
+import sys
+import warnings
 from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
 
 __all__ = [
     "get_library_path",
@@ -16,6 +22,7 @@ _LIB_NAMES = [
     "libonnxruntime_ep_iree.so",
     "onnxruntime_ep_iree.dll",
 ]
+_RUNTIME_ENV_VAR = "ONNXRUNTIME_EP_IREE_PY_RUNTIME"
 
 
 def _find_lib_in(directory: Path) -> str | None:
@@ -28,36 +35,75 @@ def _find_lib_in(directory: Path) -> str | None:
     return None
 
 
+def _get_runtime_variant() -> str:
+    runtime_variant = os.environ.get(_RUNTIME_ENV_VAR, "default").strip().lower()
+    if runtime_variant not in {"default", "tracy"}:
+        warnings.warn(
+            f"Unknown value for {_RUNTIME_ENV_VAR} ({runtime_variant}): Using default"
+        )
+        return "default"
+    return runtime_variant
+
+
+def _get_runtime_package() -> ModuleType:
+    runtime_variant = _get_runtime_variant()
+    if runtime_variant == "tracy":
+        runtime_package = importlib.import_module("onnxruntime_ep_iree_tracy")
+        print(
+            f"-- Using Tracy runtime ({_RUNTIME_ENV_VAR}=tracy)",
+            file=sys.stderr,
+        )
+        return runtime_package
+    return importlib.import_module("onnxruntime_ep_iree_default")
+
+
+def _get_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _find_variant_build_library(runtime_variant: str) -> str | None:
+    build_dir = _get_project_root() / "build" / "cmake" / runtime_variant
+    return _find_lib_in(build_dir)
+
+
+if TYPE_CHECKING:
+    _runtime_package: ModuleType
+
+
 def get_library_path() -> str:
     """Return the absolute path to the native IREE EP shared library.
 
-    Lookup order:
-      1. The packaging build directory (``<project_root>/build/cmake/default``),
-         which is where ``pip install`` / ``pip wheel`` builds the shared library.
-      2. The package directory itself (for wheel-based installs where the library
-         was bundled into the package).
-
-    Raises ``FileNotFoundError`` if the library cannot be found in either location.
+    The runtime variant is selected in ``__init__`` via
+    ``ONNXRUNTIME_EP_IREE_PY_RUNTIME`` and the shared library is resolved from
+    the corresponding built runtime package.
     """
-    pkg_dir = Path(__file__).parent
-    project_root = pkg_dir.parent.parent
+    runtime_variant = _get_runtime_variant()
+    try:
+        runtime_package = _get_runtime_package()
+    except ModuleNotFoundError:
+        runtime_package = None
+        if runtime_variant == "tracy":
+            build_result = _find_variant_build_library(runtime_variant)
+            if not build_result:
+                raise ModuleNotFoundError(
+                    "Tracy runtime requested via "
+                    f"{_RUNTIME_ENV_VAR}=tracy but it is not enabled in this build"
+                ) from None
+            return build_result
 
-    # Editable installs import Python from the source tree, so the native EP is
-    # resolved from the packaging-owned build tree instead of site-packages.
-    result = _find_lib_in(project_root / "build" / "cmake" / "default")
-    if result:
-        return result
+    if runtime_package is not None:
+        result = _find_lib_in(Path(runtime_package.__file__).resolve().parent)
+        if result:
+            return result
 
-    # Wheel installs bundle the shared library directly into the package.
-    result = _find_lib_in(pkg_dir)
+    result = _find_variant_build_library(runtime_variant)
     if result:
         return result
 
     raise FileNotFoundError(
         "IREE EP library not found. "
         "Build the package with `pip install ./python` or "
-        "`pip wheel -w dist ./python`. For editable installs, build the native library in "
-        "`build/cmake/default`."
+        "`pip wheel -w dist ./python`."
     )
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,16 +11,29 @@ from setuptools.command.build_py import build_py as _build_py
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
 SOURCE_DIR = SCRIPT_DIR.parent
-# Keep packaging-owned builds in a single stable location so editable installs,
-# wheel builds, and runtime library lookup all agree on where the native
-# artifact lives.
 DEFAULT_BUILD_DIR = SOURCE_DIR / "build" / "cmake" / "default"
+TRACY_BUILD_DIR = SOURCE_DIR / "build" / "cmake" / "tracy"
 CMAKE_EXE = os.environ.get("ONNXRUNTIME_EP_IREE_CMAKE", "cmake")
+ENABLE_TRACY = os.environ.get("ONNXRUNTIME_EP_IREE_ENABLE_TRACING", "").upper() in (
+    "1",
+    "ON",
+    "TRUE",
+)
+SELECTOR_PACKAGE = "onnxruntime_ep_iree"
+DEFAULT_PACKAGE = "onnxruntime_ep_iree_default"
+TRACY_PACKAGE = "onnxruntime_ep_iree_tracy"
 LIB_NAMES = [
     "libonnxruntime_ep_iree.dylib",
     "libonnxruntime_ep_iree.so",
     "onnxruntime_ep_iree.dll",
 ]
+REL_SOURCE_DIR = pathlib.Path(os.path.relpath(SOURCE_DIR, SCRIPT_DIR))
+REL_DEFAULT_PYTHON_DIR = pathlib.Path(
+    os.path.relpath(DEFAULT_BUILD_DIR / "python", SCRIPT_DIR)
+)
+REL_TRACY_PYTHON_DIR = pathlib.Path(
+    os.path.relpath(TRACY_BUILD_DIR / "python", SCRIPT_DIR)
+)
 
 
 def add_env_cmake_setting(
@@ -50,6 +63,13 @@ def maybe_nuke_cmake_cache(build_dir: pathlib.Path) -> str:
     return ninja_path
 
 
+def ensure_built_package(package_root: pathlib.Path) -> None:
+    package_root.mkdir(parents=True, exist_ok=True)
+    init_file = package_root / "__init__.py"
+    if not init_file.exists():
+        init_file.write_text("")
+
+
 def find_library(root_dir: pathlib.Path) -> pathlib.Path:
     candidates = []
     # CMake install layouts differ slightly across platforms and generators, so
@@ -75,9 +95,12 @@ def find_library(root_dir: pathlib.Path) -> pathlib.Path:
     return unique_candidates[0]
 
 
-def build_native_extension() -> pathlib.Path:
-    build_dir = DEFAULT_BUILD_DIR.resolve()
+def build_native_extension(
+    build_dir: pathlib.Path, extra_cmake_args: list[str] | None = None
+) -> pathlib.Path:
+    build_dir = build_dir.resolve()
     stage_dir = build_dir / "python-install"
+    extra_cmake_args = extra_cmake_args or []
     build_type = os.environ.get("ONNXRUNTIME_EP_IREE_CMAKE_BUILD_TYPE", "Release")
     generator = os.environ.get("CMAKE_GENERATOR", "Ninja")
     build_dir.mkdir(parents=True, exist_ok=True)
@@ -109,6 +132,7 @@ def build_native_extension() -> pathlib.Path:
     add_env_cmake_setting(
         cmake_args, "ONNXRUNTIME_EP_IREE_CXX_COMPILER", "CMAKE_CXX_COMPILER"
     )
+    cmake_args.extend(extra_cmake_args)
 
     subprocess.check_call([CMAKE_EXE] + cmake_args)
     subprocess.check_call(
@@ -128,11 +152,33 @@ def build_native_extension() -> pathlib.Path:
     return find_library(stage_dir)
 
 
+def copy_built_library(
+    built_library: pathlib.Path, package_root: pathlib.Path, build_py: _build_py
+) -> None:
+    ensure_built_package(package_root)
+    wheel_target_dir = pathlib.Path(build_py.build_lib) / package_root.name
+    wheel_target_dir.mkdir(parents=True, exist_ok=True)
+    for directory in [package_root, wheel_target_dir]:
+        for pattern in ("*.so", "*.dylib", "*.dll"):
+            for candidate in directory.glob(pattern):
+                candidate.unlink()
+        shutil.copyfile(built_library, directory / built_library.name)
+
+
 class CMakeBuildPy(_build_py):
     def run(self):
         super().run()
         try:
-            built_library = build_native_extension()
+            default_package_root = DEFAULT_BUILD_DIR / "python" / DEFAULT_PACKAGE
+            default_library = build_native_extension(DEFAULT_BUILD_DIR)
+            copy_built_library(default_library, default_package_root, self)
+            if ENABLE_TRACY:
+                tracy_package_root = TRACY_BUILD_DIR / "python" / TRACY_PACKAGE
+                tracy_library = build_native_extension(
+                    TRACY_BUILD_DIR,
+                    ["-DONNXRUNTIME_EP_IREE_ENABLE_TRACING=ON"],
+                )
+                copy_built_library(tracy_library, tracy_package_root, self)
         except subprocess.CalledProcessError:
             # Editable installs route through setuptools, which otherwise tends
             # to collapse native build failures into a generic packaging error.
@@ -141,14 +187,6 @@ class CMakeBuildPy(_build_py):
             print("Native build failed:")
             traceback.print_exc()
             sys.exit(1)
-        target_dir = pathlib.Path(self.build_lib) / "onnxruntime_ep_iree"
-        target_dir.mkdir(parents=True, exist_ok=True)
-        # Wheels should contain exactly the freshly staged EP library and not a
-        # leftover artifact from a previous platform or build configuration.
-        for pattern in ("*.so", "*.dylib", "*.dll"):
-            for candidate in target_dir.glob(pattern):
-                candidate.unlink()
-        shutil.copyfile(built_library, target_dir / built_library.name)
 
 
 # ---------------------------------------------------------------------------
@@ -163,22 +201,27 @@ class BinaryDistribution(Distribution):
         return True
 
 
+ensure_built_package(DEFAULT_BUILD_DIR / "python" / DEFAULT_PACKAGE)
+if ENABLE_TRACY:
+    ensure_built_package(TRACY_BUILD_DIR / "python" / TRACY_PACKAGE)
+
 setup(
     name="onnxruntime-ep-iree",
     version="0.1.0",
     description="Python helpers for the IREE ONNX Runtime Execution Provider",
-    packages=["onnxruntime_ep_iree"],
+    packages=[SELECTOR_PACKAGE, DEFAULT_PACKAGE]
+    + ([TRACY_PACKAGE] if ENABLE_TRACY else []),
+    package_dir={
+        SELECTOR_PACKAGE: SELECTOR_PACKAGE,
+        DEFAULT_PACKAGE: str(REL_DEFAULT_PYTHON_DIR / DEFAULT_PACKAGE),
+        **(
+            {TRACY_PACKAGE: str(REL_TRACY_PYTHON_DIR / TRACY_PACKAGE)}
+            if ENABLE_TRACY
+            else {}
+        ),
+    },
     cmdclass={
         "build_py": CMakeBuildPy,
-    },
-    # Include only the packaged EP shared library so stale local artifacts do
-    # not leak into wheels.
-    package_data={
-        "onnxruntime_ep_iree": [
-            "libonnxruntime_ep_iree.dylib",
-            "libonnxruntime_ep_iree.so",
-            "onnxruntime_ep_iree.dll",
-        ],
     },
     include_package_data=False,
     distclass=BinaryDistribution,

--- a/src/iree_ep_factory.cc
+++ b/src/iree_ep_factory.cc
@@ -14,7 +14,9 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 
+#include "iree/base/tracing.h"
 #include "iree_allocator.h"
 #include "iree_compile.h"
 #include "iree_data_transfer.h"
@@ -76,6 +78,11 @@ IreeEpFactory::IreeEpFactory(const char* ep_name, ApiPtrs apis,
       ApiPtrs(apis),
       logger_(default_logger),
       ep_name_(ep_name) {
+  IREE_TRACE_APP_ENTER();
+  const std::string trace_app_info =
+      std::string("onnxruntime-ep-iree ") + kEpVersion;
+  IREE_TRACE_SET_APP_INFO(trace_app_info.data(), trace_app_info.size());
+
   // Set ORT version we support.
   ort_version_supported = ORT_API_VERSION;
 
@@ -134,6 +141,8 @@ IreeEpFactory::~IreeEpFactory() {
   for (size_t i = 0; i < hw_devices_.size(); ++i) {
     ep_api.ReleaseHardwareDevice(hw_devices_[i]);
   }
+
+  IREE_TRACE_APP_EXIT(0);
 }
 
 iree_hal_device_t* IreeEpFactory::GetDeviceForId(uint32_t device_id) {


### PR DESCRIPTION
Enables building tracy wheels by default using dev_me.py and optional CMakeLists.txt support for tracy.