### PR TITLE
Update IREE to 3.12.0rc20260424

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 # Prefer to keep the IREE_GIT_TAG synced with the python-installed IREE version.
 # At a minimum, the compiler from those packages must be compatible with the
 # runtime at this source ref.
-set(IREE_GIT_TAG "v3.10.0")
+set(IREE_GIT_TAG "iree-3.12.0rc20260424")
 set(IREE_SOURCE_DIR "" CACHE FILEPATH "Path to IREE source")
 option(
   ONNXRUNTIME_EP_IREE_ENABLE_TRACING

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
-iree-base-compiler==3.10.0
+--find-links https://iree.dev/pip-release-links.html
+iree-base-compiler==3.12.0rc20260424
 onnx==1.20.0
 onnxruntime==1.24.1
 numpy

--- a/src/iree_ep_factory.cc
+++ b/src/iree_ep_factory.cc
@@ -16,6 +16,8 @@
 #include <mutex>
 #include <string>
 
+#include "iree/async/util/proactor_pool.h"
+#include "iree/base/threading/numa.h"
 #include "iree/base/tracing.h"
 #include "iree_allocator.h"
 #include "iree_compile.h"
@@ -182,11 +184,28 @@ iree_hal_device_t* IreeEpFactory::GetDeviceForIdLocked(uint32_t device_id) {
 
   // Build device URI and create HAL device.
   std::string device_uri = std::string(driver_name) + "://" + device_path;
+  iree_async_proactor_pool_t* proactor_pool = nullptr;
+  iree_status_t status = iree_async_proactor_pool_create(
+      iree_numa_node_count(), /*node_ids=*/nullptr,
+      iree_async_proactor_pool_options_default(), iree_allocator_system(),
+      &proactor_pool);
+  if (!iree_status_is_ok(status)) {
+    ORT_CXX_LOGF_NOEXCEPT(logger_, ORT_LOGGING_LEVEL_ERROR,
+                          "IREE EP: Failed to create proactor pool for %s",
+                          device_uri.c_str());
+    iree_status_ignore(status);
+    return nullptr;
+  }
+
+  iree_hal_device_create_params_t create_params =
+      iree_hal_device_create_params_default();
+  create_params.proactor_pool = proactor_pool;
   HalDevicePtr hal_device;
-  iree_status_t status = iree_hal_create_device(
+  status = iree_hal_create_device(
       iree_runtime_instance_driver_registry(IreeInstance()),
       iree_make_string_view(device_uri.data(), device_uri.size()),
-      iree_allocator_system(), hal_device.ForOutput());
+      &create_params, iree_allocator_system(), hal_device.ForOutput());
+  iree_async_proactor_pool_release(proactor_pool);
 
   if (!iree_status_is_ok(status)) {
     ORT_CXX_LOGF_NOEXCEPT(logger_, ORT_LOGGING_LEVEL_ERROR,


### PR DESCRIPTION
Fixes breaking API change to `iree_hal_create_device` that adds a proactor pool.