### PR TITLE
Fix positional semantics for absent optional ONNX inputs

### DIFF
--- a/src/iree_ort_utils.cc
+++ b/src/iree_ort_utils.cc
@@ -308,6 +308,14 @@ std::string SanitizeName(const std::string& name) {
     result = std::format("${:02X}$", static_cast<unsigned char>(first)) +
              result.substr(1);
   }
+  // Reserve a leading double underscore for internal SSA values emitted by
+  // the MLIR generator (e.g. %__none, %__raw_<name>). If a user-supplied
+  // name sanitizes to something starting with "__", escape the first
+  // underscore so it cannot collide with our internal names.
+  if (result.size() >= 2 && result[0] == '_' && result[1] == '_') {
+    result = std::format("${:02X}$", static_cast<unsigned char>('_')) +
+             result.substr(1);
+  }
   return result.empty() ? "_unnamed" : result;
 }
 

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -518,16 +518,37 @@ class MlirGenerator {
     }
 
     // Build input SSA references.
+    // Empty-name inputs represent absent optional arguments in ONNX.  We emit
+    // torch.constant.none for them so that positional semantics are preserved.
     std::ostringstream in_names;
     std::ostringstream in_types;
     bool first_input = true;
+    bool none_emitted = false;
+
+    // Helper lambda: emit torch.constant.none to represent an absent optional
+    // ONNX input, preserving positional semantics for ops like Resize.
+    auto emit_none_input = [&]() {
+      if (!none_emitted) {
+        out_ << "    %_none = torch.constant.none\n";
+        none_emitted = true;
+      }
+      if (!first_input) {
+        in_names << ", ";
+        in_types << ", ";
+      }
+      first_input = false;
+      in_names << "%_none";
+      in_types << "!torch.none";
+    };
+
     for (size_t i = 0; i < inputs.size(); ++i) {
       if (!inputs[i]) {
-        // Skip invalid inputs (optional inputs can be empty/null).
+        emit_none_input();
         continue;
       }
       std::string input_name = inputs[i].GetName();
       if (input_name.empty()) {
+        emit_none_input();
         continue;
       }
       if (!first_input) {

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -411,6 +411,10 @@ class MlirGenerator {
   }
 
   MaybeError EmitFunctionBody() {
+    // Reset per-function state.  %__none is emitted lazily on first use and
+    // each function gets its own definition.
+    none_emitted_ = false;
+
     // Emit dim constraints (util.assume.int + flow.tensor.tie_shape).
     IREE_EP_RETURN_IF_ERROR(EmitDimConstraints());
 
@@ -519,43 +523,31 @@ class MlirGenerator {
 
     // Build input SSA references.
     // Empty-name inputs represent absent optional arguments in ONNX.  We emit
-    // torch.constant.none for them so that positional semantics are preserved.
+    // torch.constant.none for them so that positional semantics are preserved
+    // (matching torch-mlir's OnnxImporter, which uses nv_map_[""]).
     std::ostringstream in_names;
     std::ostringstream in_types;
     bool first_input = true;
-    bool none_emitted = false;
-
-    // Helper lambda: emit torch.constant.none to represent an absent optional
-    // ONNX input, preserving positional semantics for ops like Resize.
-    auto emit_none_input = [&]() {
-      if (!none_emitted) {
-        out_ << "    %_none = torch.constant.none\n";
-        none_emitted = true;
-      }
-      if (!first_input) {
-        in_names << ", ";
-        in_types << ", ";
-      }
-      first_input = false;
-      in_names << "%_none";
-      in_types << "!torch.none";
-    };
 
     for (size_t i = 0; i < inputs.size(); ++i) {
-      if (!inputs[i]) {
-        emit_none_input();
-        continue;
-      }
-      std::string input_name = inputs[i].GetName();
-      if (input_name.empty()) {
-        emit_none_input();
-        continue;
-      }
       if (!first_input) {
         in_names << ", ";
         in_types << ", ";
       }
       first_input = false;
+
+      std::string input_name = inputs[i] ? inputs[i].GetName() : std::string();
+      if (input_name.empty()) {
+        // Absent optional ONNX input: reference the function-scoped
+        // %__none SSA value, emitting its definition lazily on first use.
+        if (!none_emitted_) {
+          out_ << "    %__none = torch.constant.none\n";
+          none_emitted_ = true;
+        }
+        in_names << "%__none";
+        in_types << "!torch.none";
+        continue;
+      }
       in_names << "%" << SanitizeName(input_name);
       IREE_EP_ASSIGN_OR_RETURN(std::string in_type,
                                FormatTensorType(inputs[i].TypeInfo()));
@@ -1218,6 +1210,9 @@ class MlirGenerator {
   int extern_id_ = 0;
   // Symbolic dimension names per graph input (parallel to graph_inputs_).
   std::vector<std::vector<const char*>> input_symbolic_dims_;
+  // Whether %__none = torch.constant.none has been emitted in the current
+  // function.  Reset at the start of each function body.
+  bool none_emitted_ = false;
 };
 
 // Builds an IRPA parameter archive for large initializers.

--- a/test/test_optional_inputs.py
+++ b/test/test_optional_inputs.py
@@ -10,6 +10,9 @@ import pytest
 from onnx import TensorProto, helper
 from onnx.numpy_helper import from_array
 
+# Fixed seed for reproducibility.
+np.random.seed(42)
+
 
 def _make_resize_model(use_sizes=False):
     """Build a nearest 2x Resize with absent optional inputs.
@@ -49,10 +52,21 @@ def _make_resize_model(use_sizes=False):
     return model
 
 
-@pytest.mark.gpu
+@pytest.fixture(params=["cpu", "gpu"])
+def iree_device_and_target(request):
+    """Yield (device, target_arch) for each backend."""
+    if request.param == "cpu":
+        return request.getfixturevalue("iree_device"), "host"
+    return (
+        request.getfixturevalue("iree_gpu_device"),
+        request.getfixturevalue("gpu_target"),
+    )
+
+
 @pytest.mark.parametrize("use_sizes", [False, True], ids=["scales", "sizes"])
-def test_resize_absent_inputs_e2e(iree_gpu_device, gpu_target, use_sizes):
+def test_resize_absent_inputs_e2e(iree_device_and_target, use_sizes):
     """Resize with absent optional inputs compiles and produces correct output."""
+    device, target_arch = iree_device_and_target
     model = _make_resize_model(use_sizes=use_sizes)
 
     with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
@@ -61,7 +75,7 @@ def test_resize_absent_inputs_e2e(iree_gpu_device, gpu_target, use_sizes):
 
     try:
         opts = ort.SessionOptions()
-        opts.add_provider_for_devices([iree_gpu_device], {"target_arch": gpu_target})
+        opts.add_provider_for_devices([device], {"target_arch": target_arch})
         sess = ort.InferenceSession(model_path, sess_options=opts)
 
         x = np.random.randn(1, 4, 8, 8).astype(np.float32)

--- a/test/test_optional_inputs.py
+++ b/test/test_optional_inputs.py
@@ -1,0 +1,73 @@
+"""Test that absent/optional ONNX inputs emit torch.constant.none in MLIR."""
+
+import pathlib
+import tempfile
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+from onnx import TensorProto, helper
+from onnx.numpy_helper import from_array
+
+
+def _make_resize_model(use_sizes=False):
+    """Build a nearest 2x Resize with absent optional inputs.
+
+    Args:
+        use_sizes: If False, emit Resize(X, roi="", scales)   — 1 absent input.
+                   If True,  emit Resize(X, roi="", scales="", sizes) — 2 absent.
+    """
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4, 8, 8])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4, 16, 16])
+
+    if use_sizes:
+        init = from_array(np.array([1, 4, 16, 16], dtype=np.int64), name="sizes")
+        inputs = ["X", "", "", "sizes"]
+    else:
+        init = from_array(
+            np.array([1.0, 1.0, 2.0, 2.0], dtype=np.float32), name="scales"
+        )
+        inputs = ["X", "", "scales"]
+
+    resize = helper.make_node(
+        "Resize",
+        inputs=inputs,
+        outputs=["Y"],
+        mode="nearest",
+        coordinate_transformation_mode="asymmetric",
+        nearest_mode="floor",
+    )
+
+    graph = helper.make_graph([resize], "resize_test", [X], [Y], initializer=[init])
+    model = helper.make_model(
+        graph,
+        producer_name="optional_inputs_test",
+        opset_imports=[helper.make_opsetid("", 18)],
+    )
+    model.ir_version = 9
+    return model
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("use_sizes", [False, True], ids=["scales", "sizes"])
+def test_resize_absent_inputs_e2e(iree_gpu_device, gpu_target, use_sizes):
+    """Resize with absent optional inputs compiles and produces correct output."""
+    model = _make_resize_model(use_sizes=use_sizes)
+
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        onnx.save(model, f.name)
+        model_path = f.name
+
+    try:
+        opts = ort.SessionOptions()
+        opts.add_provider_for_devices([iree_gpu_device], {"target_arch": gpu_target})
+        sess = ort.InferenceSession(model_path, sess_options=opts)
+
+        x = np.random.randn(1, 4, 8, 8).astype(np.float32)
+        result = sess.run(None, {"X": x})[0]
+
+        expected = np.repeat(np.repeat(x, 2, axis=2), 2, axis=3)
+        np.testing.assert_allclose(result, expected, rtol=0, atol=0)
+    finally:
+        pathlib.Path(model_path).unlink(missing_ok=True)

--- a/test/test_optional_inputs.py
+++ b/test/test_optional_inputs.py
@@ -14,41 +14,21 @@ from onnx.numpy_helper import from_array
 np.random.seed(42)
 
 
-def _make_resize_model(use_sizes=False):
-    """Build a nearest 2x Resize with absent optional inputs.
+def _make_clip_absent_min_model():
+    """Build Clip(X, min="", max) -- 1 absent middle input."""
+    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [4])
+    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [4])
+    max_init = from_array(np.array(2.0, dtype=np.float32), name="max")
 
-    Args:
-        use_sizes: If False, emit Resize(X, roi="", scales)   — 1 absent input.
-                   If True,  emit Resize(X, roi="", scales="", sizes) — 2 absent.
-    """
-    X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [1, 4, 8, 8])
-    Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [1, 4, 16, 16])
+    clip = helper.make_node("Clip", inputs=["X", "", "max"], outputs=["Y"])
 
-    if use_sizes:
-        init = from_array(np.array([1, 4, 16, 16], dtype=np.int64), name="sizes")
-        inputs = ["X", "", "", "sizes"]
-    else:
-        init = from_array(
-            np.array([1.0, 1.0, 2.0, 2.0], dtype=np.float32), name="scales"
-        )
-        inputs = ["X", "", "scales"]
-
-    resize = helper.make_node(
-        "Resize",
-        inputs=inputs,
-        outputs=["Y"],
-        mode="nearest",
-        coordinate_transformation_mode="asymmetric",
-        nearest_mode="floor",
-    )
-
-    graph = helper.make_graph([resize], "resize_test", [X], [Y], initializer=[init])
+    graph = helper.make_graph([clip], "clip_test", [X], [Y], initializer=[max_init])
     model = helper.make_model(
         graph,
         producer_name="optional_inputs_test",
-        opset_imports=[helper.make_opsetid("", 18)],
+        opset_imports=[helper.make_opsetid("", 17)],
     )
-    model.ir_version = 9
+    model.ir_version = 8
     return model
 
 
@@ -63,11 +43,10 @@ def iree_device_and_target(request):
     )
 
 
-@pytest.mark.parametrize("use_sizes", [False, True], ids=["scales", "sizes"])
-def test_resize_absent_inputs_e2e(iree_device_and_target, use_sizes):
-    """Resize with absent optional inputs compiles and produces correct output."""
+def test_clip_absent_min_e2e(iree_device_and_target):
+    """Clip(X, min="", max) compiles and produces correct output."""
     device, target_arch = iree_device_and_target
-    model = _make_resize_model(use_sizes=use_sizes)
+    model = _make_clip_absent_min_model()
 
     with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
         onnx.save(model, f.name)
@@ -78,10 +57,10 @@ def test_resize_absent_inputs_e2e(iree_device_and_target, use_sizes):
         opts.add_provider_for_devices([device], {"target_arch": target_arch})
         sess = ort.InferenceSession(model_path, sess_options=opts)
 
-        x = np.random.randn(1, 4, 8, 8).astype(np.float32)
+        x = np.array([-3.0, 0.0, 4.0, 7.0], dtype=np.float32)
         result = sess.run(None, {"X": x})[0]
 
-        expected = np.repeat(np.repeat(x, 2, axis=2), 2, axis=3)
+        expected = np.array([-3.0, 0.0, 2.0, 2.0], dtype=np.float32)
         np.testing.assert_allclose(result, expected, rtol=0, atol=0)
     finally:
         pathlib.Path(model_path).unlink(missing_ok=True)

--- a/test/test_optional_inputs.py
+++ b/test/test_optional_inputs.py
@@ -1,28 +1,31 @@
 """Test that absent/optional ONNX inputs emit torch.constant.none in MLIR."""
 
-import pathlib
-import tempfile
+import re
 
 import numpy as np
-import onnx
-import onnxruntime as ort
-import pytest
+from conftest import try_generate_mlir
 from onnx import TensorProto, helper
 from onnx.numpy_helper import from_array
 
-# Fixed seed for reproducibility.
-np.random.seed(42)
 
+def _make_clip_model(input_names):
+    """Build a Clip model with the given input names.
 
-def _make_clip_absent_min_model():
-    """Build Clip(X, min="", max) -- 1 absent middle input."""
+    Pass an empty string in `input_names` to mark that positional input as
+    absent (ONNX's representation of an unsupplied optional input).  Bound
+    inputs ("min" and/or "max") are emitted as scalar f32 initializers.
+    """
     X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [4])
     Y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [4])
-    max_init = from_array(np.array(2.0, dtype=np.float32), name="max")
 
-    clip = helper.make_node("Clip", inputs=["X", "", "max"], outputs=["Y"])
+    initializers = []
+    if "min" in input_names:
+        initializers.append(from_array(np.array(-1.0, dtype=np.float32), name="min"))
+    if "max" in input_names:
+        initializers.append(from_array(np.array(2.0, dtype=np.float32), name="max"))
 
-    graph = helper.make_graph([clip], "clip_test", [X], [Y], initializer=[max_init])
+    clip = helper.make_node("Clip", inputs=list(input_names), outputs=["Y"])
+    graph = helper.make_graph([clip], "clip_test", [X], [Y], initializer=initializers)
     model = helper.make_model(
         graph,
         producer_name="optional_inputs_test",
@@ -32,35 +35,40 @@ def _make_clip_absent_min_model():
     return model
 
 
-@pytest.fixture(params=["cpu", "gpu"])
-def iree_device_and_target(request):
-    """Yield (device, target_arch) for each backend."""
-    if request.param == "cpu":
-        return request.getfixturevalue("iree_device"), "host"
-    return (
-        request.getfixturevalue("iree_gpu_device"),
-        request.getfixturevalue("gpu_target"),
+def _find_clip_op_line(mlir):
+    for line in mlir.splitlines():
+        if 'torch.operator "onnx.Clip"' in line:
+            return line.strip()
+    raise AssertionError(f"onnx.Clip op not found in generated MLIR:\n{mlir}")
+
+
+def test_absent_input_emits_none_and_preserves_position(cpu_device, target_arch):
+    """Clip(X, "", max): %__none must be emitted and referenced in slot 1."""
+    model = _make_clip_model(["X", "", "max"])
+    mlir, err = try_generate_mlir(
+        model, cpu_device, "", target_arch, assert_compiles=True
     )
+    assert err is None, f"MLIR generation failed: {err}"
+
+    # The function-scoped %__none constant must be emitted exactly once.
+    assert "%__none = torch.constant.none" in mlir, mlir
+
+    # The Clip op must reference %__none in the second operand slot, between
+    # the X tensor and the max initializer.
+    op_line = _find_clip_op_line(mlir)
+    assert re.search(r"\(%X, %__none, %max\)", op_line), op_line
 
 
-def test_clip_absent_min_e2e(iree_device_and_target):
-    """Clip(X, min="", max) compiles and produces correct output."""
-    device, target_arch = iree_device_and_target
-    model = _make_clip_absent_min_model()
+def test_multiple_absent_inputs_emit_none_once(cpu_device, target_arch):
+    """Clip(X, "", "") emits a single %__none reused by both absent slots.s"""
+    model = _make_clip_model(["X", "", ""])
+    mlir, err = try_generate_mlir(
+        model, cpu_device, "", target_arch, assert_compiles=True
+    )
+    assert err is None, f"MLIR generation failed: {err}"
 
-    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
-        onnx.save(model, f.name)
-        model_path = f.name
+    # Exactly one definition of %__none in the function.
+    assert mlir.count("%__none = torch.constant.none") == 1, mlir
 
-    try:
-        opts = ort.SessionOptions()
-        opts.add_provider_for_devices([device], {"target_arch": target_arch})
-        sess = ort.InferenceSession(model_path, sess_options=opts)
-
-        x = np.array([-3.0, 0.0, 4.0, 7.0], dtype=np.float32)
-        result = sess.run(None, {"X": x})[0]
-
-        expected = np.array([-3.0, 0.0, 2.0, 2.0], dtype=np.float32)
-        np.testing.assert_allclose(result, expected, rtol=0, atol=0)
-    finally:
-        pathlib.Path(model_path).unlink(missing_ok=True)
+    op_line = _find_clip_op_line(mlir)
+    assert re.search(r"\(%X, %__none, %__none\)", op_line), op_line


### PR DESCRIPTION
The MLIR generator was silently skipping null/empty-name inputs, which broke ops like Resize that rely on positional argument order. For example, `Resize(X, roi="", scales)` would collapse to `Resize(X, scales)`, causing scales to be misinterpreted as `roi` and failing compilation.

Emit `torch.constant.none` for absent inputs instead of skipping them, matching how torch-mlir's OnnxImporter handles this via nv_map_[""].