### PR TITLE
Add output elision support for static shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ entries directly, use the full `ep.iree.*` names.
 | `extern_kernel_path` | `ep.iree.extern_kernel_path` | Empty | Directory containing precompiled extern dispatch kernel objects, such as `.co` files. |
 | `dim_specs` | `ep.iree.dim_specs` | Empty | Dimension specialization constraints. See the syntax below. |
 | `compiler_lib_path` | `ep.iree.compiler_lib_path` | Empty | Absolute path to the IREE compiler shared library. This is process-global: the first successful compiler initialization wins. If unset, the EP auto-discovers the compiler library. |
+| `enable_inplace_outputs` | `ep.iree.enable_inplace_outputs` | `1` | Set to `0` to disable in-place output emission for static-shape outputs. When enabled (the default), the generated MLIR uses the canonical Torch in-place pattern (`!torch.tensor` storage args + `torch.overwrite.tensor.contents` + `torch.copy.to_vtensor`) and the runtime pre-binds ORT-allocated output buffers at invoke time, eliminating one `stream.resource.alloca` and one post-execution copy per tied output. |
 
 ### Dimension Specialization (`dim_specs`)
 

--- a/src/iree_ep.cc
+++ b/src/iree_ep.cc
@@ -269,10 +269,12 @@ OrtStatus* ORT_API_CALL IreeEp::CompileImpl(
   ORT_CXX_LOGF_NOEXCEPT(ep->logger_, ORT_LOGGING_LEVEL_INFO,
                         "IREE EP: Generating MLIR (%zu variants)",
                         mlir_variants.size());
+  std::vector<OutputBindingInfo> output_bindings;
   IREE_ORT_RETURN_IF_MAYBE_ERROR(
       GenerateMlir(graph, ep->ort_api, mlir_file.Path(), irpa_file.Path(),
                    mlir_variants, function_names, parameter_index,
-                   parameter_provider, std::move(target_config)));
+                   parameter_provider, std::move(target_config),
+                   output_bindings, ep->config_.enable_inplace_outputs));
 
   // Phase 2: Compile MLIR to VMFB.
   std::vector<std::string> flags = GenerateCompileFlags(ep->config_);
@@ -319,7 +321,7 @@ OrtStatus* ORT_API_CALL IreeEp::CompileImpl(
   auto* info = new IreeNodeComputeInfo(
       *ep, std::move(vmfb_data), std::move(parameter_index),
       std::move(parameter_provider), std::move(variant_infos),
-      std::move(dim_mappings));
+      std::move(dim_mappings), std::move(output_bindings));
   node_compute_infos[0] = info;
 
   ORT_CXX_LOGF_NOEXCEPT(ep->logger_, ORT_LOGGING_LEVEL_INFO,
@@ -396,13 +398,15 @@ IreeNodeComputeInfo::IreeNodeComputeInfo(
     IreeEp& ep_ref, std::vector<uint8_t> vmfb_data,
     ParameterIndexPtr parameter_index, ParameterProviderPtr parameter_provider,
     std::vector<VariantInfo> variant_infos,
-    std::vector<SymbolicDimMapping> dim_mappings)
+    std::vector<SymbolicDimMapping> dim_mappings,
+    std::vector<OutputBindingInfo> output_bindings)
     : ep(ep_ref),
       vmfb_data_(std::move(vmfb_data)),
       parameter_index_(std::move(parameter_index)),
       parameter_provider_(std::move(parameter_provider)),
       variant_infos_(std::move(variant_infos)),
-      dim_mappings_(std::move(dim_mappings)) {
+      dim_mappings_(std::move(dim_mappings)),
+      output_bindings_(std::move(output_bindings)) {
   ort_version_supported = ORT_API_VERSION;
   CreateState = CreateStateImpl;
   Compute = ComputeImpl;
@@ -523,19 +527,63 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
         iree_runtime_call_inputs_push_back_buffer_view(call.Get(), view.Get()));
   }
 
+  // Caller-provided output storage.
+  // For each tied output (currently only static-shape outputs), pre-allocate
+  // the ORT-side output and bind it as an extra IREE input AFTER the regular
+  // inputs, in result-index order. We must always push a storage arg for every
+  // is_tied output so the wrapper's input arity matches what EmitFunctionHeader
+  // emitted. We retain the wrapping HalBufferViewPtr for each tied output so
+  // the runtime call's input list keeps a valid ref through invocation.
+  std::vector<HalBufferViewPtr> tied_output_views;
+  tied_output_views.reserve(info->output_bindings_.size());
+  std::vector<bool> bound_in_place(info->output_bindings_.size(), false);
+  for (size_t i = 0; i < info->output_bindings_.size(); ++i) {
+    const auto& binding = info->output_bindings_[i];
+    if (!binding.is_tied) continue;
+
+    // ctx.GetOutput uses the static shape captured at MLIR-gen time. If the
+    // user has IO-bound a pre-allocated output, this returns that buffer;
+    // otherwise ORT allocates one for us.
+    Ort::UnownedValue ort_out =
+        ctx.GetOutput(i, binding.shape.data(), binding.shape.size());
+
+    // Vendor-id check decides whether `OrtTensorToIreeBufferView` will
+    // go through zero-copy or allocate-and-copy. Mirrors the predicate inside
+    // `OrtTensorToIreeBufferView` helper.
+    const OrtMemoryDevice* mem_device = info->ep.ep_api.Value_GetMemoryDevice(
+        static_cast<const OrtValue*>(ort_out));
+    bool on_iree_device =
+        mem_device &&
+        info->ep.ep_api.MemoryDevice_GetVendorId(mem_device) == kEpVendorId;
+    if (!on_iree_device) {
+      ORT_CXX_LOGF_NOEXCEPT(
+          info->ep.Logger(), ORT_LOGGING_LEVEL_VERBOSE,
+          "IREE EP: tied output %zu is not on the IREE device; pushing an "
+          "EP-side storage buffer and copying back after invocation",
+          i);
+    }
+
+    iree_hal_buffer_view_t* storage_view = nullptr;
+    ORT_RETURN_IF_ERROR(OrtTensorToIreeBufferView(
+        Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
+        allocator, iree_allocator_system(), &storage_view, info->ep.ep_api,
+        info->ep.Logger()));
+    tied_output_views.emplace_back(storage_view);
+    IREE_ORT_RETURN_IF_ERROR(iree_runtime_call_inputs_push_back_buffer_view(
+        call.Get(), storage_view));
+    bound_in_place[i] = on_iree_device;
+  }
+
   // Invoke the function.
   IREE_ORT_RETURN_IF_ERROR(
       iree_runtime_call_invoke(call.Get(), IREE_RUNTIME_CALL_FLAG_RESERVED));
 
-  // Pop outputs and copy to ORT tensors.
-  //
-  // TODO(perf): Currently IREE allocates its own output buffers, then we copy
-  // to ORT's pre-allocated device buffers (D2D copy). The way to properly
-  // eliminate this is by passing mutable dps buffers as part of the iree input
-  // signature and writing to them. The problem is that ORT doesn't give us a
-  // good way to infer the output shape. I'm not sure what the right fix is.
-  // Maybe we could have a custom iree allocator that does the job for us?
-  // I'm just not sure how to do this properly.
+  // Pop outputs. For outputs that were actually bound in place, the popped
+  // bufferview aliases the caller-provided storage and ORT already has the data
+  // via the tensor handed back from `ctx.GetOutput`.
+  // NOTE: Outputs that were tied at compile time but fell back at runtime
+  // (vendor-id mismatch) and untied/dynamic-shape outputs both go through
+  // the legacy allocate-and-copy path below.
   iree_vm_list_t* output_list = iree_runtime_call_outputs(call.Get());
   iree_host_size_t output_count = iree_vm_list_size(output_list);
 
@@ -545,6 +593,11 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
     IREE_ORT_RETURN_IF_ERROR(iree_runtime_call_outputs_pop_front_buffer_view(
         call.Get(), &output_view));
     HalBufferViewPtr output_view_ptr(output_view);
+
+    // In-place outputs: data is already where ORT expects it, nothing to do.
+    if (i < bound_in_place.size() && bound_in_place[i]) {
+      continue;
+    }
 
     // Get shape and element type from IREE buffer view.
     std::vector<int64_t> shape = GetBufferViewShape(output_view);

--- a/src/iree_ep.cc
+++ b/src/iree_ep.cc
@@ -547,27 +547,36 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
     Ort::UnownedValue ort_out =
         ctx.GetOutput(i, binding.shape.data(), binding.shape.size());
 
-    // Vendor-id check decides whether `OrtTensorToIreeBufferView` will
-    // go through zero-copy or allocate-and-copy. Mirrors the predicate inside
-    // `OrtTensorToIreeBufferView` helper.
+    // Vendor-id check decides whether the ORT tensor lives on our device:
+    //  - on device: zero-copy wrap via OrtTensorToIreeBufferView so the
+    //    kernel writes directly into the caller's buffer (true in-place).
+    //  - on host: allocate an EP-side device-local storage buffer with
+    //    AllocateIreeStorageForOrtTensor (no contents are copied; the
+    //    output bytes are uninitialized on entry and the kernel produces
+    //    them) and fall back to the post-execution device-to-host copy.
     const OrtMemoryDevice* mem_device = info->ep.ep_api.Value_GetMemoryDevice(
         static_cast<const OrtValue*>(ort_out));
     bool on_iree_device =
         mem_device &&
         info->ep.ep_api.MemoryDevice_GetVendorId(mem_device) == kEpVendorId;
-    if (!on_iree_device) {
-      ORT_CXX_LOGF_NOEXCEPT(
-          info->ep.Logger(), ORT_LOGGING_LEVEL_VERBOSE,
-          "IREE EP: tied output %zu is not on the IREE device; pushing an "
-          "EP-side storage buffer and copying back after invocation",
-          i);
-    }
 
     iree_hal_buffer_view_t* storage_view = nullptr;
-    ORT_RETURN_IF_ERROR(OrtTensorToIreeBufferView(
-        Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
-        allocator, iree_allocator_system(), &storage_view, info->ep.ep_api,
-        info->ep.Logger()));
+    if (on_iree_device) {
+      ORT_RETURN_IF_ERROR(OrtTensorToIreeBufferView(
+          Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
+          allocator, iree_allocator_system(), &storage_view, info->ep.ep_api,
+          info->ep.Logger()));
+    } else {
+      ORT_CXX_LOGF_NOEXCEPT(
+          info->ep.Logger(), ORT_LOGGING_LEVEL_VERBOSE,
+          "IREE EP: tied output %zu is not on the IREE device; allocating "
+          "an EP-side storage buffer (no copy) and copying back after "
+          "invocation",
+          i);
+      ORT_RETURN_IF_ERROR(AllocateIreeStorageForOrtTensor(
+          Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
+          allocator, &storage_view));
+    }
     tied_output_views.emplace_back(storage_view);
     IREE_ORT_RETURN_IF_ERROR(iree_runtime_call_inputs_push_back_buffer_view(
         call.Get(), storage_view));

--- a/src/iree_ep.cc
+++ b/src/iree_ep.cc
@@ -270,11 +270,10 @@ OrtStatus* ORT_API_CALL IreeEp::CompileImpl(
                         "IREE EP: Generating MLIR (%zu variants)",
                         mlir_variants.size());
   std::vector<OutputBindingInfo> output_bindings;
-  IREE_ORT_RETURN_IF_MAYBE_ERROR(
-      GenerateMlir(graph, ep->ort_api, mlir_file.Path(), irpa_file.Path(),
-                   mlir_variants, function_names, parameter_index,
-                   parameter_provider, std::move(target_config),
-                   output_bindings, ep->config_.enable_inplace_outputs));
+  IREE_ORT_RETURN_IF_MAYBE_ERROR(GenerateMlir(
+      graph, ep->ort_api, mlir_file.Path(), irpa_file.Path(), mlir_variants,
+      std::move(target_config), ep->config_.enable_inplace_outputs,
+      function_names, parameter_index, parameter_provider, output_bindings));
 
   // Phase 2: Compile MLIR to VMFB.
   std::vector<std::string> flags = GenerateCompileFlags(ep->config_);
@@ -511,7 +510,7 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
     iree_hal_buffer_view_t* view = nullptr;
     ORT_RETURN_IF_ERROR(OrtTensorToIreeBufferView(
         input, device, allocator, iree_allocator_system(), &view,
-        info->ep.ep_api, info->ep.Logger()));
+        info->ep.ep_api, info->ep.DeviceId(), info->ep.Logger()));
     input_views.emplace_back(view);
   }
 
@@ -531,21 +530,24 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
   // For each tied output (currently only static-shape outputs), pre-allocate
   // the ORT-side output and bind it as an extra IREE input AFTER the regular
   // inputs, in result-index order. We must always push a storage arg for every
-  // is_tied output so the wrapper's input arity matches what EmitFunctionHeader
-  // emitted. We retain the wrapping HalBufferViewPtr for each tied output so
-  // the runtime call's input list keeps a valid ref through invocation.
-  std::vector<HalBufferViewPtr> tied_output_views;
-  tied_output_views.reserve(info->output_bindings_.size());
+  // tied output so the wrapper's input arity matches what EmitFunctionHeader
+  // emitted. iree_runtime_call_inputs_push_back_buffer_view retains its own
+  // ref on each pushed view (via iree_vm_list_push_ref_retain), so the call's
+  // input list keeps the view alive across invoke on its own. Our local
+  // HalBufferViewPtr therefore exists only to drop the extra ref we hold
+  // after a successful push_back and to release the view if push_back itself
+  // errors out (in which case no retain happened and we still own the sole
+  // ref).
   std::vector<bool> bound_in_place(info->output_bindings_.size(), false);
   for (size_t i = 0; i < info->output_bindings_.size(); ++i) {
     const auto& binding = info->output_bindings_[i];
-    if (!binding.is_tied) continue;
+    if (!binding.shape.has_value()) continue;
 
     // ctx.GetOutput uses the static shape captured at MLIR-gen time. If the
     // user has IO-bound a pre-allocated output, this returns that buffer;
     // otherwise ORT allocates one for us.
     Ort::UnownedValue ort_out =
-        ctx.GetOutput(i, binding.shape.data(), binding.shape.size());
+        ctx.GetOutput(i, binding.shape->data(), binding.shape->size());
 
     // Vendor-id + device-id check decides whether the ORT tensor lives on
     // our IREE device:
@@ -574,7 +576,7 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
       ORT_RETURN_IF_ERROR(OrtTensorToIreeBufferView(
           Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
           allocator, iree_allocator_system(), &storage_view, info->ep.ep_api,
-          info->ep.Logger()));
+          info->ep.DeviceId(), info->ep.Logger()));
     } else {
       ORT_CXX_LOGF_NOEXCEPT(
           info->ep.Logger(), ORT_LOGGING_LEVEL_VERBOSE,
@@ -586,7 +588,7 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
           Ort::ConstValue{static_cast<const OrtValue*>(ort_out)}, device,
           allocator, &storage_view));
     }
-    tied_output_views.emplace_back(storage_view);
+    HalBufferViewPtr storage_view_ptr(storage_view);
     IREE_ORT_RETURN_IF_ERROR(iree_runtime_call_inputs_push_back_buffer_view(
         call.Get(), storage_view));
     bound_in_place[i] = on_iree_device;
@@ -631,8 +633,9 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
 
     // Allocate ORT output tensor and copy data from IREE buffer.
     Ort::UnownedValue output = ctx.GetOutput(i, shape.data(), shape.size());
-    ORT_RETURN_IF_ERROR(IreeBufferViewToOrtTensor(
-        output_view, output, device, info->ep.ep_api, info->ep.Logger()));
+    ORT_RETURN_IF_ERROR(
+        IreeBufferViewToOrtTensor(output_view, output, device, info->ep.ep_api,
+                                  info->ep.DeviceId(), info->ep.Logger()));
   }
   return nullptr;
 }

--- a/src/iree_ep.cc
+++ b/src/iree_ep.cc
@@ -547,18 +547,27 @@ OrtStatus* ORT_API_CALL IreeNodeComputeInfo::ComputeImpl(
     Ort::UnownedValue ort_out =
         ctx.GetOutput(i, binding.shape.data(), binding.shape.size());
 
-    // Vendor-id check decides whether the ORT tensor lives on our device:
+    // Vendor-id + device-id check decides whether the ORT tensor lives on
+    // our IREE device:
     //  - on device: zero-copy wrap via OrtTensorToIreeBufferView so the
     //    kernel writes directly into the caller's buffer (true in-place).
-    //  - on host: allocate an EP-side device-local storage buffer with
-    //    AllocateIreeStorageForOrtTensor (no contents are copied; the
-    //    output bytes are uninitialized on entry and the kernel produces
-    //    them) and fall back to the post-execution device-to-host copy.
+    //  - elsewhere (host or another IREE device): allocate an EP-side
+    //    device-local storage buffer with AllocateIreeStorageForOrtTensor
+    //    (no contents are copied; the output bytes are uninitialized on
+    //    entry and the kernel produces them) and fall back to the
+    //    post-execution device-to-host copy.
+    // TODO: Add support for device interoperability.
     const OrtMemoryDevice* mem_device = info->ep.ep_api.Value_GetMemoryDevice(
         static_cast<const OrtValue*>(ort_out));
-    bool on_iree_device =
-        mem_device &&
-        info->ep.ep_api.MemoryDevice_GetVendorId(mem_device) == kEpVendorId;
+    bool on_iree_device = false;
+    if (mem_device) {
+      uint32_t mem_vendor_id =
+          info->ep.ep_api.MemoryDevice_GetVendorId(mem_device);
+      uint32_t mem_device_id =
+          info->ep.ep_api.MemoryDevice_GetDeviceId(mem_device);
+      on_iree_device = (mem_vendor_id == kEpVendorId &&
+                        mem_device_id == info->ep.DeviceId());
+    }
 
     iree_hal_buffer_view_t* storage_view = nullptr;
     if (on_iree_device) {

--- a/src/iree_ep.h
+++ b/src/iree_ep.h
@@ -70,6 +70,9 @@ class IreeEp : public OrtEp, public ApiPtrs {
   // Accessor for the IREE device (from factory's device cache).
   [[nodiscard]] iree_hal_device_t* IreeDevice() const;
 
+  // Accessor for the IREE device ID.
+  [[nodiscard]] uint32_t DeviceId() const { return device_id_; }
+
   // Accessor for the logger.
   [[nodiscard]] const Ort::Logger& Logger() const { return logger_; }
 

--- a/src/iree_ep.h
+++ b/src/iree_ep.h
@@ -192,7 +192,7 @@ struct IreeNodeComputeInfo : OrtNodeComputeInfo {
   // Mappings from symbolic names to input tensor positions for dispatch.
   std::vector<SymbolicDimMapping> dim_mappings_;
   // Per-output binding info captured during MLIR generation.
-  std::vector<OutputBindingInfo> output_bindings_;
+  const std::vector<OutputBindingInfo> output_bindings_;
 
   // Runtime state (lazily initialized on first ComputeImpl call).
   RuntimeSessionPtr session_;

--- a/src/iree_ep.h
+++ b/src/iree_ep.h
@@ -22,6 +22,7 @@
 #include "dim_spec.h"
 #include "iree_ep_factory.h"
 #include "iree_wrappers.h"
+#include "mlir_gen.h"
 #include "ort_import.h"
 
 namespace onnxruntime::iree {
@@ -51,6 +52,14 @@ class IreeEp : public OrtEp, public ApiPtrs {
     std::string extern_kernel_path = "";
     // Parsed dim spec variants from "ep.iree.dim_specs" session option.
     std::vector<DimSpecVariant> dim_spec_variants;
+    // Flag to emit the canonical Torch in-place-output pattern which basically
+    // consists of the following :-
+    // 1. `!torch.tensor` storage args.
+    // 2. `torch.overwrite.tensor.contents`
+    // 3. `torch.copy.to_vtensor`.
+    // Currently enabled for static-shape outputs and pre-binds ORT-allocated
+    // output buffers at invoke time. Default on.
+    bool enable_inplace_outputs = true;
   };
 
   IreeEp(IreeEpFactory& factory, const std::string& name, const Config& config,
@@ -147,7 +156,8 @@ struct IreeNodeComputeInfo : OrtNodeComputeInfo {
                       ParameterIndexPtr parameter_index,
                       ParameterProviderPtr parameter_provider,
                       std::vector<VariantInfo> variant_infos,
-                      std::vector<SymbolicDimMapping> dim_mappings);
+                      std::vector<SymbolicDimMapping> dim_mappings,
+                      std::vector<OutputBindingInfo> output_bindings);
 
   ~IreeNodeComputeInfo();
 
@@ -178,6 +188,8 @@ struct IreeNodeComputeInfo : OrtNodeComputeInfo {
   std::vector<VariantInfo> variant_infos_;
   // Mappings from symbolic names to input tensor positions for dispatch.
   std::vector<SymbolicDimMapping> dim_mappings_;
+  // Per-output binding info captured during MLIR generation.
+  std::vector<OutputBindingInfo> output_bindings_;
 
   // Runtime state (lazily initialized on first ComputeImpl call).
   RuntimeSessionPtr session_;

--- a/src/iree_ep_factory.cc
+++ b/src/iree_ep_factory.cc
@@ -432,6 +432,9 @@ OrtStatus* ORT_API_CALL IreeEpFactory::CreateEpImpl(
                                           "0") == "1";
     config.extern_kernel_path =
         sess_opts.GetConfigEntryOrDefault("ep.iree.extern_kernel_path", "");
+    config.enable_inplace_outputs =
+        sess_opts.GetConfigEntryOrDefault("ep.iree.enable_inplace_outputs",
+                                          "1") == "1";
 
     std::string dim_specs_str =
         sess_opts.GetConfigEntryOrDefault("ep.iree.dim_specs", "");

--- a/src/iree_ort_utils.cc
+++ b/src/iree_ort_utils.cc
@@ -211,6 +211,54 @@ OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
   return nullptr;
 }
 
+OrtStatus* AllocateIreeStorageForOrtTensor(
+    const Ort::ConstValue& ort_value, iree_hal_device_t* device,
+    iree_hal_allocator_t* allocator, iree_hal_buffer_view_t** out_buffer_view) {
+  *out_buffer_view = nullptr;
+
+  auto type_info = ort_value.GetTensorTypeAndShapeInfo();
+  auto onnx_dtype = type_info.GetElementType();
+  auto shape = type_info.GetShape();
+
+  iree_hal_element_type_t iree_dtype = OnnxToIreeElementType(onnx_dtype);
+  if (iree_dtype == IREE_HAL_ELEMENT_TYPE_NONE) {
+    return Ort::Status("IREE EP: Unsupported element type", ORT_NOT_IMPLEMENTED)
+        .release();
+  }
+
+  std::vector<iree_hal_dim_t> iree_shape(shape.begin(), shape.end());
+  size_t byte_size = CalculateTensorByteSize(shape, onnx_dtype);
+
+  // Mirror the empty-tensor guard in OrtTensorToIreeBufferView. See the note
+  // there for context on the HIP-driver quirk this works around.
+  if (byte_size == 0) {
+    return Ort::Status(
+               "IREE EP: Empty tensors are not yet supported on HIP "
+               "backends",
+               ORT_INVALID_ARGUMENT)
+        .release();
+  }
+
+  iree_hal_buffer_params_t buffer_params = {};
+  buffer_params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  buffer_params.usage = IREE_HAL_BUFFER_USAGE_DEFAULT;
+
+  // Allocate the buffer (no initial data => no host-to-device copy).
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_ORT_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      allocator, buffer_params, byte_size, &buffer));
+
+  iree_status_t view_status = iree_hal_buffer_view_create(
+      buffer, iree_shape.size(), iree_shape.data(), iree_dtype,
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+      iree_hal_device_host_allocator(device), out_buffer_view);
+  // The view retains the buffer; release our local ref unconditionally.
+  iree_hal_buffer_release(buffer);
+  IREE_ORT_RETURN_IF_ERROR(view_status);
+
+  return nullptr;
+}
+
 OrtStatus* IreeBufferViewToOrtTensor(iree_hal_buffer_view_t* buffer_view,
                                      Ort::UnownedValue ort_value,
                                      iree_hal_device_t* device,

--- a/src/iree_ort_utils.cc
+++ b/src/iree_ort_utils.cc
@@ -126,13 +126,28 @@ size_t OnnxElementTypeSize(ONNXTensorElementDataType type) {
 // Buffer/Tensor Conversion
 // ============================================================================
 
-OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
-                                     iree_hal_device_t* device,
-                                     iree_hal_allocator_t* allocator,
-                                     iree_allocator_t /*host_allocator*/,
-                                     iree_hal_buffer_view_t** out_buffer_view,
-                                     const OrtEpApi& ep_api,
-                                     const Ort::Logger& logger) {
+// Builds the explicit-error status returned when an ORT tensor's device_id
+// matches kEpVendorId but resolves to a different IREE device than the
+// caller's EP.
+static OrtStatus* MakeCrossDeviceError(const char* role,
+                                       uint32_t tensor_device_id,
+                                       uint32_t ep_device_id) {
+  return Ort::Status(
+             std::format(
+                 "IREE EP: {} tensor lives on a different IREE device "
+                 "(device_id={}) than this EP (device_id={}); cross "
+                 "IREE-device transfer must be done via OrtDataTransfer",
+                 role, tensor_device_id, ep_device_id)
+                 .c_str(),
+             ORT_INVALID_ARGUMENT)
+      .release();
+}
+
+OrtStatus* OrtTensorToIreeBufferView(
+    const Ort::ConstValue& ort_value, iree_hal_device_t* device,
+    iree_hal_allocator_t* allocator, iree_allocator_t /*host_allocator*/,
+    iree_hal_buffer_view_t** out_buffer_view, const OrtEpApi& ep_api,
+    uint32_t ep_device_id, const Ort::Logger& logger) {
   *out_buffer_view = nullptr;
 
   // Get tensor info from ORT.
@@ -163,12 +178,17 @@ OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
         .release();
   }
 
-  // Check if tensor is already on an IREE device.
+  // Check if tensor is already on our IREE device (both vendor_id and
+  // device_id must match).
   const OrtMemoryDevice* mem_device =
       ep_api.Value_GetMemoryDevice(ort_value.operator const OrtValue*());
   if (mem_device) {
     uint32_t vendor_id = ep_api.MemoryDevice_GetVendorId(mem_device);
+    uint32_t device_id = ep_api.MemoryDevice_GetDeviceId(mem_device);
     if (vendor_id == kEpVendorId) {
+      if (device_id != ep_device_id) {
+        return MakeCrossDeviceError("input", device_id, ep_device_id);
+      }
       // Tensor already on IREE device - wrap existing buffer without copy.
       ORT_CXX_LOGF_NOEXCEPT(logger, ORT_LOGGING_LEVEL_INFO,
                             "IREE EP: Input tensor already on device, "
@@ -263,18 +283,24 @@ OrtStatus* IreeBufferViewToOrtTensor(iree_hal_buffer_view_t* buffer_view,
                                      Ort::UnownedValue ort_value,
                                      iree_hal_device_t* device,
                                      const OrtEpApi& ep_api,
+                                     uint32_t ep_device_id,
                                      const Ort::Logger& logger) {
   // Get buffer from view.
   iree_hal_buffer_t* buffer = iree_hal_buffer_view_buffer(buffer_view);
   iree_device_size_t byte_length =
       iree_hal_buffer_view_byte_length(buffer_view);
 
-  // Check if output tensor is on an IREE device.
+  // Check if output tensor is on our IREE device (both vendor_id and
+  // device_id must match).
   const OrtMemoryDevice* mem_device =
       ep_api.Value_GetMemoryDevice(ort_value.operator OrtValue*());
   if (mem_device) {
     uint32_t vendor_id = ep_api.MemoryDevice_GetVendorId(mem_device);
+    uint32_t device_id = ep_api.MemoryDevice_GetDeviceId(mem_device);
     if (vendor_id == kEpVendorId) {
+      if (device_id != ep_device_id) {
+        return MakeCrossDeviceError("output", device_id, ep_device_id);
+      }
       // Output is on device - copy buffer directly (D2D).
       ORT_CXX_LOGF_NOEXCEPT(logger, ORT_LOGGING_LEVEL_INFO,
                             "IREE EP: Output tensor on device, performing D2D "

--- a/src/iree_ort_utils.h
+++ b/src/iree_ort_utils.h
@@ -181,9 +181,14 @@ size_t OnnxElementTypeSize(ONNXTensorElementDataType type);
 
 // Converts an ORT input tensor to an IREE buffer view.
 //
-// If the tensor is already on an IREE device (detected via vendor_id), the
-// existing buffer is wrapped in a view without copying data. Otherwise, a new
-// buffer is allocated on the device and data is copied from host.
+// If the tensor is already on the caller's IREE device (vendor_id and
+// device_id both match), the existing buffer is wrapped in a view without
+// copying data. If the tensor is on a different IREE device (vendor matches
+// but device_id does not), the function returns an explicit error rather
+// than silently aliasing a buffer that belongs to a different device — cross
+// IREE-device transfer must be done via the OrtDataTransfer interface.
+// Otherwise (host or non-IREE device), a new buffer is allocated on the
+// device and data is copied from host.
 //
 // Parameters:
 //   ort_value - Input ORT tensor (const, read-only)
@@ -192,16 +197,16 @@ size_t OnnxElementTypeSize(ONNXTensorElementDataType type);
 //   host_allocator - Host allocator for metadata
 //   out_buffer_view - Output buffer view (caller must release)
 //   ep_api - EP API for checking memory device info
+//   ep_device_id - Caller EP's device id (used together with vendor_id to
+//                  decide whether ort_value lives on the caller's device)
 //   logger - Logger for tracing
 //
 // Returns nullptr on success, OrtStatus* on error.
-OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
-                                     iree_hal_device_t* device,
-                                     iree_hal_allocator_t* allocator,
-                                     iree_allocator_t host_allocator,
-                                     iree_hal_buffer_view_t** out_buffer_view,
-                                     const OrtEpApi& ep_api,
-                                     const Ort::Logger& logger);
+OrtStatus* OrtTensorToIreeBufferView(
+    const Ort::ConstValue& ort_value, iree_hal_device_t* device,
+    iree_hal_allocator_t* allocator, iree_allocator_t host_allocator,
+    iree_hal_buffer_view_t** out_buffer_view, const OrtEpApi& ep_api,
+    uint32_t ep_device_id, const Ort::Logger& logger);
 
 // Allocates a fresh IREE device-local buffer view for an ORT tensor, without
 // reading or copying its contents.
@@ -224,15 +229,22 @@ OrtStatus* AllocateIreeStorageForOrtTensor(
 
 // Copies data from an IREE buffer view to an ORT output tensor.
 //
-// If the output tensor is on an IREE device (detected via vendor_id), the
-// buffer is copied directly without device-to-host transfer. Otherwise, data
-// is transferred from device to host memory.
+// If the output tensor is on the caller's IREE device (vendor_id and
+// device_id both match), the buffer is copied directly without
+// device-to-host transfer. If the tensor is on a different IREE device
+// (vendor matches but device_id does not), the function returns an explicit
+// error rather than issuing a D2D from the caller's device into a buffer
+// owned by another device — cross IREE-device transfer must be done via the
+// OrtDataTransfer interface. Otherwise (host or non-IREE device), data is
+// transferred from device to host memory.
 //
 // Parameters:
 //   buffer_view - Input IREE buffer view
 //   ort_value - Output ORT tensor (mutable)
 //   device - IREE HAL device for transfer
 //   ep_api - EP API for checking memory device info
+//   ep_device_id - Caller EP's device id (used together with vendor_id to
+//                  decide whether ort_value lives on the caller's device)
 //   logger - Logger for tracing
 //
 // Returns nullptr on success, OrtStatus* on error.
@@ -240,6 +252,7 @@ OrtStatus* IreeBufferViewToOrtTensor(iree_hal_buffer_view_t* buffer_view,
                                      Ort::UnownedValue ort_value,
                                      iree_hal_device_t* device,
                                      const OrtEpApi& ep_api,
+                                     uint32_t ep_device_id,
                                      const Ort::Logger& logger);
 
 // Extracts shape from an IREE buffer view as int64_t vector for ORT.

--- a/src/iree_ort_utils.h
+++ b/src/iree_ort_utils.h
@@ -203,6 +203,29 @@ OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
                                      const OrtEpApi& ep_api,
                                      const Ort::Logger& logger);
 
+// Allocates a fresh IREE device-local buffer view sized for the shape and
+// element type of |ort_value|, WITHOUT reading or copying its contents.
+//
+// Intended for caller-provided output storage when the ORT-allocated output
+// tensor is host-resident (so we can't zero-copy wrap it). The kernel writes
+// the output into the returned buffer; the caller is responsible for the
+// post-execution device-to-host copy back into |ort_value|.
+//
+// For input tensors (which need their host data on the device) use
+// OrtTensorToIreeBufferView instead.
+//
+// Parameters:
+//   ort_value - ORT tensor whose shape and element type seed the allocation
+//               (contents are not read)
+//   device - IREE HAL device for allocation
+//   allocator - Device allocator from session
+//   out_buffer_view - Output buffer view (caller must release)
+//
+// Returns nullptr on success, OrtStatus* on error.
+OrtStatus* AllocateIreeStorageForOrtTensor(
+    const Ort::ConstValue& ort_value, iree_hal_device_t* device,
+    iree_hal_allocator_t* allocator, iree_hal_buffer_view_t** out_buffer_view);
+
 // Copies data from an IREE buffer view to an ORT output tensor.
 //
 // If the output tensor is on an IREE device (detected via vendor_id), the

--- a/src/iree_ort_utils.h
+++ b/src/iree_ort_utils.h
@@ -203,20 +203,16 @@ OrtStatus* OrtTensorToIreeBufferView(const Ort::ConstValue& ort_value,
                                      const OrtEpApi& ep_api,
                                      const Ort::Logger& logger);
 
-// Allocates a fresh IREE device-local buffer view sized for the shape and
-// element type of |ort_value|, WITHOUT reading or copying its contents.
+// Allocates a fresh IREE device-local buffer view for an ORT tensor, without
+// reading or copying its contents.
 //
 // Intended for caller-provided output storage when the ORT-allocated output
-// tensor is host-resident (so we can't zero-copy wrap it). The kernel writes
-// the output into the returned buffer; the caller is responsible for the
-// post-execution device-to-host copy back into |ort_value|.
-//
-// For input tensors (which need their host data on the device) use
-// OrtTensorToIreeBufferView instead.
+// tensor is host-resident and cannot be zero-copy wrapped. The kernel writes
+// into the returned buffer; the caller is responsible for the post-execution
+// device-to-host copy back into ort_value.
 //
 // Parameters:
 //   ort_value - ORT tensor whose shape and element type seed the allocation
-//               (contents are not read)
 //   device - IREE HAL device for allocation
 //   allocator - Device allocator from session
 //   out_buffer_view - Output buffer view (caller must release)

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -180,12 +180,15 @@ ErrorOr<std::string> FormatTensorType(const Ort::ConstTypeInfo& type_info) {
   return FormatTorchTensorTypeImpl(type_info, /*value_semantics=*/true);
 }
 
-// Internal SSA names for the in-place output pattern. The suffix is the
-// position of the storage arg in the function signature, which is unique
-// within a function and cannot be derived from any sanitized ONNX
-// identifier (which never starts with `__iree_ep_`), so these are
-// guaranteed to be collision-free with names emitted elsewhere in the
-// generator.
+// Internal SSA names for the in-place output pattern.
+//
+// Collision-free with any sanitized ONNX identifier because SanitizeName
+// reserves the leading `__` prefix (any user name that would sanitize to
+// `__...` has its first underscore escaped to `$5F$`).
+//
+// TODO: replace this prefix scheme once the planned graph-wide name
+// uniquifier (tracked in a follow-up PR) lands; that helper will subsume
+// this and the other ad-hoc prefixes emitted by the MLIR generator.
 static std::string InPlaceStorageName(size_t storage_arg_pos) {
   return std::format("__iree_ep_inplace_storage_{}", storage_arg_pos);
 }
@@ -273,6 +276,7 @@ class MlirGenerator {
     function_names.clear();
     function_names.reserve(variants.size());
 
+    ComputeOutputBindings();
     EmitModulePrologue();
     for (const auto& v : variants) {
       ConfigureForVariant(*v.specs, v.suffix);
@@ -354,6 +358,32 @@ class MlirGenerator {
     }
   }
 
+  // Computes which outputs are tied to a caller-provided storage arg and the
+  // storage arg's position in the function signature. Invariant across
+  // variants, so call once after CollectMetadata() and before any variant
+  // emission.
+  // TODO: Revisit once dynamic output shapes are supported.
+  void ComputeOutputBindings() {
+    output_bindings_.assign(graph_outputs_.size(), OutputBindingInfo{});
+    storage_arg_indices_.assign(graph_outputs_.size(), kNoStorageArg);
+    if (!enable_inplace_outputs_) {
+      // Disabled by session option: leave every binding marked
+      // is_tied=false so EmitFunctionHeader/EmitReturn fall back to the
+      // legacy out-of-place lowering and the runtime side stays on the
+      // post-execution copy path.
+      return;
+    }
+    size_t storage_arg_pos = graph_inputs_.size();
+    for (size_t i = 0; i < graph_outputs_.size(); ++i) {
+      const auto type_info = graph_outputs_[i].TypeInfo();
+      if (!IsStaticShape(type_info)) continue;
+      auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+      output_bindings_[i].is_tied = true;
+      output_bindings_[i].shape = tensor_info.GetShape();
+      storage_arg_indices_[i] = storage_arg_pos++;
+    }
+  }
+
   // Configures the generator for a variant (dim specs, function name suffix).
   // Must be called before EmitFunctionHeader/EmitFunctionBody for each variant.
   void ConfigureForVariant(const DimSpecVariant& specs,
@@ -410,29 +440,6 @@ class MlirGenerator {
   // For static-shape outputs, also emits an extra mutable storage arg per
   // output after the regular inputs.
   MaybeError EmitFunctionHeader() {
-    // Decide which outputs are tied (static-shape) and assign each a position
-    // in the function arg list AFTER the regular inputs. Populate the
-    // per-variant binding info so the runtime side can pre-bind ORT-allocated
-    // output buffers before invoke. The bindings are identical across
-    // variants (static shape doesn't change), so we only populate this on the
-    // first variant emission.
-    if (output_bindings_.empty()) {
-      output_bindings_.assign(graph_outputs_.size(), OutputBindingInfo{});
-      // When the session option disables the in-place pattern, leave every
-      // binding marked is_tied=false so EmitFunctionHeader/EmitReturn fall
-      // back to the legacy out-of-place lowering and the runtime side stays
-      // on the post-execution copy path.
-      if (enable_inplace_outputs_) {
-        for (size_t i = 0; i < graph_outputs_.size(); ++i) {
-          const auto type_info = graph_outputs_[i].TypeInfo();
-          if (!IsStaticShape(type_info)) continue;
-          auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
-          output_bindings_[i].is_tied = true;
-          output_bindings_[i].shape = tensor_info.GetShape();
-        }
-      }
-    }
-
     std::ostringstream args;
     for (size_t i = 0; i < graph_inputs_.size(); ++i) {
       if (i > 0) {
@@ -449,21 +456,18 @@ class MlirGenerator {
     }
 
     // Append storage args for static-shape outputs, in result-index order.
-    // The arg index recorded here (graph_inputs_.size() + counter) is the
+    // Indices were precomputed by ComputeOutputBindings(); each is the
     // position the runtime side pushes the ORT-allocated buffer view at.
-    size_t storage_arg_pos = graph_inputs_.size();
-    storage_arg_indices_.assign(graph_outputs_.size(), kNoStorageArg);
     for (size_t i = 0; i < graph_outputs_.size(); ++i) {
-      if (!output_bindings_[i].is_tied) continue;
-      if (storage_arg_pos > 0) {
+      if (storage_arg_indices_[i] == kNoStorageArg) continue;
+      if (storage_arg_indices_[i] > 0) {
         args << ", ";
       }
       IREE_EP_ASSIGN_OR_RETURN(
           std::string storage_type,
           FormatStorageTensorType(graph_outputs_[i].TypeInfo()));
-      args << "%" << InPlaceStorageName(storage_arg_pos) << ": "
+      args << "%" << InPlaceStorageName(storage_arg_indices_[i]) << ": "
            << storage_type;
-      storage_arg_indices_[i] = storage_arg_pos++;
     }
 
     // Build return types.
@@ -1340,7 +1344,7 @@ class MlirGenerator {
   bool enable_inplace_outputs_ = false;
 
  public:
-  const std::vector<OutputBindingInfo>& output_bindings() const {
+  const std::vector<OutputBindingInfo>& GetOutputBindings() const {
     return output_bindings_;
   }
 };
@@ -1518,7 +1522,7 @@ MaybeError GenerateMlir(
   }
 
   IREE_EP_RETURN_IF_ERROR(gen.BuildParameterArchive(out_index, out_provider));
-  out_output_bindings = gen.output_bindings();
+  out_output_bindings = gen.GetOutputBindings();
   return ok();
 }
 

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -134,11 +134,12 @@ static bool IsStaticShape(const Ort::ConstTypeInfo& type_info) {
   return true;
 }
 
-// Emits the storage-arg torch type, which differs from the body's value-
-// semantics type by using NonValueTensor (`!torch.tensor` vs `!torch.vtensor`).
-// The mutable form is what `torch.overwrite.tensor.contents` requires.
-static ErrorOr<std::string> FormatStorageTensorType(
-    const Ort::ConstTypeInfo& type_info) {
+// Shared body of FormatTensorType / FormatStorageTensorType. The only
+// difference between the value-semantics form (`!torch.vtensor`) and the
+// mutable storage form (`!torch.tensor`) is the leading keyword; everything
+// else (shape, dtype) is identical.
+static ErrorOr<std::string> FormatTorchTensorTypeImpl(
+    const Ort::ConstTypeInfo& type_info, bool value_semantics) {
   if (type_info.GetONNXType() != ONNX_TYPE_TENSOR) {
     return errorWithCode(ErrorCode::kNotImplemented,
                          "Non-tensor type {} not supported",
@@ -149,39 +150,9 @@ static ErrorOr<std::string> FormatStorageTensorType(
   auto dtype = tensor_info.GetElementType();
 
   std::ostringstream ss;
-  ss << "!torch.tensor<[";
+  ss << (value_semantics ? "!torch.vtensor<[" : "!torch.tensor<[");
   for (size_t i = 0; i < shape.size(); ++i) {
     if (i > 0) ss << ",";
-    if (shape[i] < 0) {
-      ss << "?";
-    } else {
-      ss << shape[i];
-    }
-  }
-  IREE_EP_ASSIGN_OR_RETURN(std::string elem_type, GetElementType(dtype));
-  ss << "]," << elem_type << ">";
-  return ss.str();
-}
-
-// Formats a tensor type as !torch.vtensor<[dims],dtype>.
-// Dynamic dims are always emitted as "?".
-ErrorOr<std::string> FormatTensorType(const Ort::ConstTypeInfo& type_info) {
-  if (type_info.GetONNXType() != ONNX_TYPE_TENSOR) {
-    return errorWithCode(ErrorCode::kNotImplemented,
-                         "Non-tensor type {} not supported",
-                         static_cast<int>(type_info.GetONNXType()));
-  }
-
-  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
-  auto shape = tensor_info.GetShape();
-  auto dtype = tensor_info.GetElementType();
-
-  std::ostringstream ss;
-  ss << "!torch.vtensor<[";
-  for (size_t i = 0; i < shape.size(); ++i) {
-    if (i > 0) {
-      ss << ",";
-    }
     if (shape[i] < 0) {
       // TODO: Ensure that dynamic dimensions are actually represented as -1. I
       // checked and they seem to but an example to check would be good.
@@ -193,6 +164,33 @@ ErrorOr<std::string> FormatTensorType(const Ort::ConstTypeInfo& type_info) {
   IREE_EP_ASSIGN_OR_RETURN(std::string elem_type, GetElementType(dtype));
   ss << "]," << elem_type << ">";
   return ss.str();
+}
+
+// Formats a tensor type as !torch.tensor<[dims],dtype> (mutable / non-value
+// semantics). This is the form `torch.overwrite.tensor.contents` requires
+// for its destination operand.
+static ErrorOr<std::string> FormatStorageTensorType(
+    const Ort::ConstTypeInfo& type_info) {
+  return FormatTorchTensorTypeImpl(type_info, /*value_semantics=*/false);
+}
+
+// Formats a tensor type as !torch.vtensor<[dims],dtype>.
+// Dynamic dims are always emitted as "?".
+ErrorOr<std::string> FormatTensorType(const Ort::ConstTypeInfo& type_info) {
+  return FormatTorchTensorTypeImpl(type_info, /*value_semantics=*/true);
+}
+
+// Internal SSA names for the in-place output pattern. The suffix is the
+// position of the storage arg in the function signature, which is unique
+// within a function and cannot be derived from any sanitized ONNX
+// identifier (which never starts with `__iree_ep_`), so these are
+// guaranteed to be collision-free with names emitted elsewhere in the
+// generator.
+static std::string InPlaceStorageName(size_t storage_arg_pos) {
+  return std::format("__iree_ep_inplace_storage_{}", storage_arg_pos);
+}
+static std::string InPlaceStorageVtName(size_t storage_arg_pos) {
+  return std::format("__iree_ep_inplace_storage_vt_{}", storage_arg_pos);
 }
 
 // Formats a tensor type as tensor<dimsxdtype> (standard MLIR format).
@@ -460,11 +458,11 @@ class MlirGenerator {
       if (storage_arg_pos > 0) {
         args << ", ";
       }
-      std::string name = SanitizeName(graph_outputs_[i].GetName());
       IREE_EP_ASSIGN_OR_RETURN(
           std::string storage_type,
           FormatStorageTensorType(graph_outputs_[i].TypeInfo()));
-      args << "%out_" << name << ": " << storage_type;
+      args << "%" << InPlaceStorageName(storage_arg_pos) << ": "
+           << storage_type;
       storage_arg_indices_[i] = storage_arg_pos++;
     }
 
@@ -1104,24 +1102,29 @@ class MlirGenerator {
   MaybeError EmitReturn() {
     // For each tied (static-shape) output, write the freshly-computed result
     // into the caller-provided storage arg, then read it back as a vtensor.
-    // Returning the post-overwrite read (instead of the original SSA result)
-    // is what lets the codegen fold the result allocation into the storage
-    // arg's buffer.
+    // The torch.copy.to_vtensor is purely a value-semantics bridge so we can
+    // satisfy the function's `-> !torch.vtensor` return type from the
+    // mutable `!torch.tensor` storage arg; it does NOT introduce a new
+    // allocation. The IREE pipeline (Torch -> Linalg -> Stream) recognizes
+    // the overwrite + copy.to_vtensor pair against a function-level storage
+    // arg and folds the result into the storage arg's backing buffer.
     for (size_t i = 0; i < graph_outputs_.size(); ++i) {
       if (storage_arg_indices_[i] == kNoStorageArg) continue;
       std::string name = SanitizeName(graph_outputs_[i].GetName());
+      std::string storage_name = InPlaceStorageName(storage_arg_indices_[i]);
+      std::string storage_vt_name =
+          InPlaceStorageVtName(storage_arg_indices_[i]);
       IREE_EP_ASSIGN_OR_RETURN(std::string vtensor_type,
                                FormatTensorType(graph_outputs_[i].TypeInfo()));
       IREE_EP_ASSIGN_OR_RETURN(
           std::string storage_type,
           FormatStorageTensorType(graph_outputs_[i].TypeInfo()));
       out_ << std::format(
-          "    torch.overwrite.tensor.contents %{0} overwrites %out_{0} : "
-          "{1}, {2}\n",
-          name, vtensor_type, storage_type);
-      out_ << std::format(
-          "    %{0}__storage_vt = torch.copy.to_vtensor %out_{0} : {1}\n", name,
-          vtensor_type);
+          "    torch.overwrite.tensor.contents %{0} overwrites %{1} : "
+          "{2}, {3}\n",
+          name, storage_name, vtensor_type, storage_type);
+      out_ << std::format("    %{0} = torch.copy.to_vtensor %{1} : {2}\n",
+                          storage_vt_name, storage_name, vtensor_type);
     }
 
     std::ostringstream ret_values;
@@ -1131,11 +1134,10 @@ class MlirGenerator {
         ret_values << ", ";
         ret_types << ", ";
       }
-      std::string name = SanitizeName(graph_outputs_[i].GetName());
       if (storage_arg_indices_[i] != kNoStorageArg) {
-        ret_values << "%" << name << "__storage_vt";
+        ret_values << "%" << InPlaceStorageVtName(storage_arg_indices_[i]);
       } else {
-        ret_values << "%" << name;
+        ret_values << "%" << SanitizeName(graph_outputs_[i].GetName());
       }
       IREE_EP_ASSIGN_OR_RETURN(std::string ret_type,
                                FormatTensorType(graph_outputs_[i].TypeInfo()));

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -269,14 +269,16 @@ class MlirGenerator {
   // All functions share the same module (and thus the same parameter
   // references), so when compiled to a single VMFB the weights are shared.
   // For the unspecialized case, pass a single variant with empty suffix/specs.
-  // Populates function_names with the MLIR function name for each variant.
+  // Populates function_names with the MLIR function name for each variant
+  // and output_bindings with one entry per graph output (in order).
   MaybeError Generate(const std::vector<VariantInfo>& variants,
-                      std::vector<std::string>& function_names) {
+                      std::vector<std::string>& function_names,
+                      std::vector<OutputBindingInfo>& output_bindings) {
     CollectMetadata();
     function_names.clear();
     function_names.reserve(variants.size());
 
-    ComputeOutputBindings();
+    output_bindings = ComputeOutputBindings();
     EmitModulePrologue();
     for (const auto& v : variants) {
       ConfigureForVariant(*v.specs, v.suffix);
@@ -361,27 +363,29 @@ class MlirGenerator {
   // Computes which outputs are tied to a caller-provided storage arg and the
   // storage arg's position in the function signature. Invariant across
   // variants, so call once after CollectMetadata() and before any variant
-  // emission.
+  // emission. Returns the per-output binding info for the caller; also
+  // populates storage_arg_indices_ which is read by EmitFunctionHeader and
+  // EmitReturn during emission.
   // TODO: Revisit once dynamic output shapes are supported.
-  void ComputeOutputBindings() {
-    output_bindings_.assign(graph_outputs_.size(), OutputBindingInfo{});
+  std::vector<OutputBindingInfo> ComputeOutputBindings() {
+    std::vector<OutputBindingInfo> bindings(graph_outputs_.size());
     storage_arg_indices_.assign(graph_outputs_.size(), kNoStorageArg);
     if (!enable_inplace_outputs_) {
-      // Disabled by session option: leave every binding marked
-      // is_tied=false so EmitFunctionHeader/EmitReturn fall back to the
-      // legacy out-of-place lowering and the runtime side stays on the
+      // Disabled by session option: leave every binding's shape as
+      // nullopt so EmitFunctionHeader/EmitReturn fall back to the legacy
+      // out-of-place lowering and the runtime side stays on the
       // post-execution copy path.
-      return;
+      return bindings;
     }
     size_t storage_arg_pos = graph_inputs_.size();
     for (size_t i = 0; i < graph_outputs_.size(); ++i) {
       const auto type_info = graph_outputs_[i].TypeInfo();
       if (!IsStaticShape(type_info)) continue;
       auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
-      output_bindings_[i].is_tied = true;
-      output_bindings_[i].shape = tensor_info.GetShape();
+      bindings[i].shape = tensor_info.GetShape();
       storage_arg_indices_[i] = storage_arg_pos++;
     }
+    return bindings;
   }
 
   // Configures the generator for a variant (dim specs, function name suffix).
@@ -1336,17 +1340,11 @@ class MlirGenerator {
   bool none_emitted_ = false;
 
   static constexpr size_t kNoStorageArg = static_cast<size_t>(-1);
-  std::vector<OutputBindingInfo> output_bindings_;
   // storage-arg index in the function's arg list, or kNoStorageArg if the
   // output is dynamic.
   std::vector<size_t> storage_arg_indices_;
   // Flag to emit the canonical in-place pattern.
   bool enable_inplace_outputs_ = false;
-
- public:
-  const std::vector<OutputBindingInfo>& GetOutputBindings() const {
-    return output_bindings_;
-  }
 };
 
 // Builds an IRPA parameter archive for large initializers.
@@ -1497,10 +1495,10 @@ MaybeError GenerateMlir(
     const Ort::ConstGraph& graph, const OrtApi& /*ort_api*/,
     const std::string& mlir_path, const std::string& irpa_path,
     const std::vector<std::pair<std::string, DimSpecVariant>>& variants,
+    TargetConfig target_config, bool enable_inplace_outputs,
     std::vector<std::string>& out_function_names, ParameterIndexPtr& out_index,
-    ParameterProviderPtr& out_provider, TargetConfig target_config,
-    std::vector<OutputBindingInfo>& out_output_bindings,
-    bool enable_inplace_outputs) {
+    ParameterProviderPtr& out_provider,
+    std::vector<OutputBindingInfo>& out_output_bindings) {
   std::ofstream file(mlir_path);
   if (!file.is_open()) {
     return error("Failed to open output file: {}", mlir_path);
@@ -1514,16 +1512,15 @@ MaybeError GenerateMlir(
   for (const auto& [suffix, specs] : variants) {
     infos.push_back({suffix, &specs});
   }
-  IREE_EP_RETURN_IF_ERROR(gen.Generate(infos, out_function_names));
+  IREE_EP_RETURN_IF_ERROR(
+      gen.Generate(infos, out_function_names, out_output_bindings));
 
   file.close();
   if (file.fail()) {
     return error("Failed to write to file: {}", mlir_path);
   }
 
-  IREE_EP_RETURN_IF_ERROR(gen.BuildParameterArchive(out_index, out_provider));
-  out_output_bindings = gen.GetOutputBindings();
-  return ok();
+  return gen.BuildParameterArchive(out_index, out_provider);
 }
 
 }  // namespace onnxruntime::iree

--- a/src/mlir_gen.cc
+++ b/src/mlir_gen.cc
@@ -121,6 +121,48 @@ ErrorOr<std::string> GetElementType(ONNXTensorElementDataType dtype,
   }
 }
 
+// Returns true iff every dim in the tensor's shape is static i.e. >= 0.
+static bool IsStaticShape(const Ort::ConstTypeInfo& type_info) {
+  if (type_info.GetONNXType() != ONNX_TYPE_TENSOR) {
+    return false;
+  }
+  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+  auto shape = tensor_info.GetShape();
+  for (int64_t d : shape) {
+    if (d < 0) return false;
+  }
+  return true;
+}
+
+// Emits the storage-arg torch type, which differs from the body's value-
+// semantics type by using NonValueTensor (`!torch.tensor` vs `!torch.vtensor`).
+// The mutable form is what `torch.overwrite.tensor.contents` requires.
+static ErrorOr<std::string> FormatStorageTensorType(
+    const Ort::ConstTypeInfo& type_info) {
+  if (type_info.GetONNXType() != ONNX_TYPE_TENSOR) {
+    return errorWithCode(ErrorCode::kNotImplemented,
+                         "Non-tensor type {} not supported",
+                         static_cast<int>(type_info.GetONNXType()));
+  }
+  auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+  auto shape = tensor_info.GetShape();
+  auto dtype = tensor_info.GetElementType();
+
+  std::ostringstream ss;
+  ss << "!torch.tensor<[";
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (i > 0) ss << ",";
+    if (shape[i] < 0) {
+      ss << "?";
+    } else {
+      ss << shape[i];
+    }
+  }
+  IREE_EP_ASSIGN_OR_RETURN(std::string elem_type, GetElementType(dtype));
+  ss << "]," << elem_type << ">";
+  return ss.str();
+}
+
 // Formats a tensor type as !torch.vtensor<[dims],dtype>.
 // Dynamic dims are always emitted as "?".
 ErrorOr<std::string> FormatTensorType(const Ort::ConstTypeInfo& type_info) {
@@ -208,11 +250,13 @@ bool ParseInputRef(const std::string& spec, size_t& input_idx) {
 class MlirGenerator {
  public:
   MlirGenerator(const Ort::ConstGraph& graph, std::ostream& out,
-                const std::string& irpa_path, TargetConfig target_config)
+                const std::string& irpa_path, TargetConfig target_config,
+                bool enable_inplace_outputs)
       : graph_(graph),
         out_(out),
         irpa_path_(irpa_path),
-        target_config_(std::move(target_config)) {}
+        target_config_(std::move(target_config)),
+        enable_inplace_outputs_(enable_inplace_outputs) {}
 
   // A single (suffix, dim_specs) variant for MLIR generation.
   struct VariantInfo {
@@ -364,7 +408,33 @@ class MlirGenerator {
   // Emits the function signature with current dim specs and function name.
   // Constrained input args are renamed to %name__orig so EmitDimConstraints()
   // can rebind the original name after applying shape assumptions.
+  //
+  // For static-shape outputs, also emits an extra mutable storage arg per
+  // output after the regular inputs.
   MaybeError EmitFunctionHeader() {
+    // Decide which outputs are tied (static-shape) and assign each a position
+    // in the function arg list AFTER the regular inputs. Populate the
+    // per-variant binding info so the runtime side can pre-bind ORT-allocated
+    // output buffers before invoke. The bindings are identical across
+    // variants (static shape doesn't change), so we only populate this on the
+    // first variant emission.
+    if (output_bindings_.empty()) {
+      output_bindings_.assign(graph_outputs_.size(), OutputBindingInfo{});
+      // When the session option disables the in-place pattern, leave every
+      // binding marked is_tied=false so EmitFunctionHeader/EmitReturn fall
+      // back to the legacy out-of-place lowering and the runtime side stays
+      // on the post-execution copy path.
+      if (enable_inplace_outputs_) {
+        for (size_t i = 0; i < graph_outputs_.size(); ++i) {
+          const auto type_info = graph_outputs_[i].TypeInfo();
+          if (!IsStaticShape(type_info)) continue;
+          auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
+          output_bindings_[i].is_tied = true;
+          output_bindings_[i].shape = tensor_info.GetShape();
+        }
+      }
+    }
+
     std::ostringstream args;
     for (size_t i = 0; i < graph_inputs_.size(); ++i) {
       if (i > 0) {
@@ -378,6 +448,24 @@ class MlirGenerator {
       } else {
         args << "%" << name << ": " << type;
       }
+    }
+
+    // Append storage args for static-shape outputs, in result-index order.
+    // The arg index recorded here (graph_inputs_.size() + counter) is the
+    // position the runtime side pushes the ORT-allocated buffer view at.
+    size_t storage_arg_pos = graph_inputs_.size();
+    storage_arg_indices_.assign(graph_outputs_.size(), kNoStorageArg);
+    for (size_t i = 0; i < graph_outputs_.size(); ++i) {
+      if (!output_bindings_[i].is_tied) continue;
+      if (storage_arg_pos > 0) {
+        args << ", ";
+      }
+      std::string name = SanitizeName(graph_outputs_[i].GetName());
+      IREE_EP_ASSIGN_OR_RETURN(
+          std::string storage_type,
+          FormatStorageTensorType(graph_outputs_[i].TypeInfo()));
+      args << "%out_" << name << ": " << storage_type;
+      storage_arg_indices_[i] = storage_arg_pos++;
     }
 
     // Build return types.
@@ -1014,6 +1102,28 @@ class MlirGenerator {
   }
 
   MaybeError EmitReturn() {
+    // For each tied (static-shape) output, write the freshly-computed result
+    // into the caller-provided storage arg, then read it back as a vtensor.
+    // Returning the post-overwrite read (instead of the original SSA result)
+    // is what lets the codegen fold the result allocation into the storage
+    // arg's buffer.
+    for (size_t i = 0; i < graph_outputs_.size(); ++i) {
+      if (storage_arg_indices_[i] == kNoStorageArg) continue;
+      std::string name = SanitizeName(graph_outputs_[i].GetName());
+      IREE_EP_ASSIGN_OR_RETURN(std::string vtensor_type,
+                               FormatTensorType(graph_outputs_[i].TypeInfo()));
+      IREE_EP_ASSIGN_OR_RETURN(
+          std::string storage_type,
+          FormatStorageTensorType(graph_outputs_[i].TypeInfo()));
+      out_ << std::format(
+          "    torch.overwrite.tensor.contents %{0} overwrites %out_{0} : "
+          "{1}, {2}\n",
+          name, vtensor_type, storage_type);
+      out_ << std::format(
+          "    %{0}__storage_vt = torch.copy.to_vtensor %out_{0} : {1}\n", name,
+          vtensor_type);
+    }
+
     std::ostringstream ret_values;
     std::ostringstream ret_types;
     for (size_t i = 0; i < graph_outputs_.size(); ++i) {
@@ -1021,7 +1131,12 @@ class MlirGenerator {
         ret_values << ", ";
         ret_types << ", ";
       }
-      ret_values << "%" << SanitizeName(graph_outputs_[i].GetName());
+      std::string name = SanitizeName(graph_outputs_[i].GetName());
+      if (storage_arg_indices_[i] != kNoStorageArg) {
+        ret_values << "%" << name << "__storage_vt";
+      } else {
+        ret_values << "%" << name;
+      }
       IREE_EP_ASSIGN_OR_RETURN(std::string ret_type,
                                FormatTensorType(graph_outputs_[i].TypeInfo()));
       ret_types << ret_type;
@@ -1213,6 +1328,19 @@ class MlirGenerator {
   // Whether %__none = torch.constant.none has been emitted in the current
   // function.  Reset at the start of each function body.
   bool none_emitted_ = false;
+
+  static constexpr size_t kNoStorageArg = static_cast<size_t>(-1);
+  std::vector<OutputBindingInfo> output_bindings_;
+  // storage-arg index in the function's arg list, or kNoStorageArg if the
+  // output is dynamic.
+  std::vector<size_t> storage_arg_indices_;
+  // Flag to emit the canonical in-place pattern.
+  bool enable_inplace_outputs_ = false;
+
+ public:
+  const std::vector<OutputBindingInfo>& output_bindings() const {
+    return output_bindings_;
+  }
 };
 
 // Builds an IRPA parameter archive for large initializers.
@@ -1364,13 +1492,16 @@ MaybeError GenerateMlir(
     const std::string& mlir_path, const std::string& irpa_path,
     const std::vector<std::pair<std::string, DimSpecVariant>>& variants,
     std::vector<std::string>& out_function_names, ParameterIndexPtr& out_index,
-    ParameterProviderPtr& out_provider, TargetConfig target_config) {
+    ParameterProviderPtr& out_provider, TargetConfig target_config,
+    std::vector<OutputBindingInfo>& out_output_bindings,
+    bool enable_inplace_outputs) {
   std::ofstream file(mlir_path);
   if (!file.is_open()) {
     return error("Failed to open output file: {}", mlir_path);
   }
 
-  MlirGenerator gen(graph, file, irpa_path, std::move(target_config));
+  MlirGenerator gen(graph, file, irpa_path, std::move(target_config),
+                    enable_inplace_outputs);
 
   std::vector<MlirGenerator::VariantInfo> infos;
   infos.reserve(variants.size());
@@ -1385,6 +1516,7 @@ MaybeError GenerateMlir(
   }
 
   IREE_EP_RETURN_IF_ERROR(gen.BuildParameterArchive(out_index, out_provider));
+  out_output_bindings = gen.output_bindings();
   return ok();
 }
 

--- a/src/mlir_gen.h
+++ b/src/mlir_gen.h
@@ -23,6 +23,7 @@
 #ifndef ONNXRUNTIME_EP_IREE_SRC_MLIR_GEN_H_
 #define ONNXRUNTIME_EP_IREE_SRC_MLIR_GEN_H_
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -33,6 +34,16 @@
 #include "support.h"
 
 namespace onnxruntime::iree {
+
+// Per-output binding info produced by GenerateMlir, consumed by
+// IreeEp::ComputeImpl to decide how to hand each output to IREE.
+struct OutputBindingInfo {
+  // True iff the generated MLIR carries a caller-provided storage arg for
+  // this result.
+  bool is_tied = false;
+  // Static shape from the ONNX graph; only valid when is_tied.
+  std::vector<int64_t> shape;
+};
 
 // Target configuration passed to the MLIR generator. Always populated with the
 // EP's main target arch and backend. When the graph contains
@@ -73,7 +84,9 @@ MaybeError GenerateMlir(
     const std::string& mlir_path, const std::string& irpa_path,
     const std::vector<std::pair<std::string, DimSpecVariant>>& variants,
     std::vector<std::string>& out_function_names, ParameterIndexPtr& out_index,
-    ParameterProviderPtr& out_provider, TargetConfig target_config);
+    ParameterProviderPtr& out_provider, TargetConfig target_config,
+    std::vector<OutputBindingInfo>& out_output_bindings,
+    bool enable_inplace_outputs = false);
 
 }  // namespace onnxruntime::iree
 

--- a/src/mlir_gen.h
+++ b/src/mlir_gen.h
@@ -24,6 +24,7 @@
 #define ONNXRUNTIME_EP_IREE_SRC_MLIR_GEN_H_
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,11 +39,9 @@ namespace onnxruntime::iree {
 // Per-output binding info produced by GenerateMlir, consumed by
 // IreeEp::ComputeImpl to decide how to hand each output to IREE.
 struct OutputBindingInfo {
-  // True iff the generated MLIR carries a caller-provided storage arg for
-  // this result.
-  bool is_tied = false;
-  // Static shape from the ONNX graph; only valid when is_tied.
-  std::vector<int64_t> shape;
+  // Static shape from the ONNX graph if the generated MLIR carries a
+  // caller-provided storage arg for this result; nullopt otherwise.
+  std::optional<std::vector<int64_t>> shape;
 };
 
 // Target configuration passed to the MLIR generator. Always populated with the
@@ -83,10 +82,10 @@ MaybeError GenerateMlir(
     const Ort::ConstGraph& graph, const OrtApi& ort_api,
     const std::string& mlir_path, const std::string& irpa_path,
     const std::vector<std::pair<std::string, DimSpecVariant>>& variants,
+    TargetConfig target_config, bool enable_inplace_outputs,
     std::vector<std::string>& out_function_names, ParameterIndexPtr& out_index,
-    ParameterProviderPtr& out_provider, TargetConfig target_config,
-    std::vector<OutputBindingInfo>& out_output_bindings,
-    bool enable_inplace_outputs = false);
+    ParameterProviderPtr& out_provider,
+    std::vector<OutputBindingInfo>& out_output_bindings);
 
 }  // namespace onnxruntime::iree
 

--- a/test/test_cross_device.py
+++ b/test/test_cross_device.py
@@ -1,0 +1,121 @@
+"""Tests for the cross IREE-device guard"""
+
+import pathlib
+import tempfile
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+from onnx import TensorProto, helper
+
+
+def _find_iree_device(driver):
+    for d in ort.get_ep_devices():
+        if d.ep_name == "IREE" and d.device.metadata.get("iree.driver") == driver:
+            return d
+    return None
+
+
+@pytest.fixture(scope="module")
+def cpu_device_pair(register_ep):
+    """The two CPU-only IREE devices we need; skip if either is absent."""
+    a = _find_iree_device("local-task")
+    b = _find_iree_device("local-sync")
+    if a is None or b is None:
+        pytest.skip(
+            "Cross IREE-device tests require both local-task and "
+            "local-sync IREE EP devices."
+        )
+    return a, b
+
+
+def _make_static_add_model():
+    """`C = A + B` on shape (8, 8); B is a baked-in constant."""
+    shape = [8, 8]
+    rng = np.random.default_rng(seed=7)
+    a = rng.standard_normal(shape, dtype=np.float32)
+    b = rng.standard_normal(shape, dtype=np.float32)
+
+    input_a = helper.make_tensor_value_info("A", TensorProto.FLOAT, shape)
+    output_c = helper.make_tensor_value_info("C", TensorProto.FLOAT, shape)
+    constant_node = helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=["B"],
+        value=helper.make_tensor(
+            name="const_tensor",
+            data_type=TensorProto.FLOAT,
+            dims=shape,
+            vals=b.flatten().tolist(),
+        ),
+    )
+    add_node = helper.make_node("Add", inputs=["A", "B"], outputs=["C"])
+    graph = helper.make_graph(
+        [constant_node, add_node],
+        "cross_device_test_graph",
+        [input_a],
+        [output_c],
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="iree_test",
+        opset_imports=[helper.make_opsetid("", 17)],
+    )
+    model.ir_version = 8
+    return model, a, b
+
+
+def _alloc_on_iree_device(shape, device):
+    return ort.OrtValue.ortvalue_from_shape_and_type(
+        list(shape),
+        np.float32,
+        device_type="gpu",
+        device_id=device.device.device_id,
+        vendor_id=device.device.vendor_id,
+    )
+
+
+@pytest.mark.parametrize("bind_side", ["input", "output"])
+def test_cross_device_binding(cpu_device_pair, bind_side):
+    """An IO-bound tensor on a different IREE device than the session's
+    must either round-trip correctly through OrtDataTransfer or raise an
+    error that explicitly names the cross IREE-device case."""
+    session_device, foreign_device = cpu_device_pair
+    model, a, b = _make_static_add_model()
+
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        onnx.save(model, f.name)
+        model_path = f.name
+
+    try:
+        sess_opts = ort.SessionOptions()
+        sess_opts.add_provider_for_devices([session_device], {"target_arch": "host"})
+        session = ort.InferenceSession(model_path, sess_options=sess_opts)
+
+        io_binding = session.io_binding()
+        if bind_side == "input":
+            foreign_input = _alloc_on_iree_device(a.shape, foreign_device)
+            foreign_input.update_inplace(a)
+            io_binding.bind_ortvalue_input("A", foreign_input)
+            io_binding.bind_output("C")
+        else:
+            foreign_output = _alloc_on_iree_device(a.shape, foreign_device)
+            io_binding.bind_cpu_input("A", a)
+            io_binding.bind_ortvalue_output("C", foreign_output)
+
+        try:
+            session.run_with_iobinding(io_binding)
+        except Exception as e:
+            assert "different IREE device" in str(e) or "device_id" in str(
+                e
+            ), f"Expected a cross-device error message, got: {e!r}"
+            return
+
+        if bind_side == "input":
+            [out] = io_binding.copy_outputs_to_cpu()
+        else:
+            out = foreign_output.numpy()
+        np.testing.assert_allclose(out, a + b, rtol=1e-5, atol=1e-5)
+    finally:
+        pathlib.Path(model_path).unlink(missing_ok=True)

--- a/test/test_inplace_outputs.py
+++ b/test/test_inplace_outputs.py
@@ -1,0 +1,118 @@
+"""Tests for in-place output emission (`ep.iree.enable_inplace_outputs`).
+
+These tests lock in the contract for the session option:
+
+  - unset:                     in-place ON  (the default)
+  - explicit "1":              in-place ON
+  - explicit "0":              in-place OFF (kill switch)
+
+…and guard numerical correctness via a parity check so we never regress
+to silently returning an unwritten output buffer (the failure mode if
+the runtime-side device check ever drifts from the compiler emission).
+"""
+
+import pathlib
+import tempfile
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from conftest import try_generate_mlir
+from onnx import TensorProto, helper
+
+
+def _make_static_add_model(shape=(64, 64)):
+    """Return (model, A, B) for `C = A + B` with fully static shapes."""
+    rng = np.random.default_rng(seed=42)
+    a = rng.standard_normal(shape, dtype=np.float32)
+    b = rng.standard_normal(shape, dtype=np.float32)
+
+    input_a = helper.make_tensor_value_info("A", TensorProto.FLOAT, list(shape))
+    output_c = helper.make_tensor_value_info("C", TensorProto.FLOAT, list(shape))
+    constant_node = helper.make_node(
+        "Constant",
+        inputs=[],
+        outputs=["B"],
+        value=helper.make_tensor(
+            name="const_tensor",
+            data_type=TensorProto.FLOAT,
+            dims=list(shape),
+            vals=b.flatten().tolist(),
+        ),
+    )
+    add_node = helper.make_node("Add", inputs=["A", "B"], outputs=["C"])
+    graph = helper.make_graph(
+        [constant_node, add_node], "inplace_test_graph", [input_a], [output_c]
+    )
+    model = helper.make_model(
+        graph,
+        producer_name="iree_test",
+        opset_imports=[helper.make_opsetid("", 17)],
+    )
+    model.ir_version = 8
+    return model, a, b
+
+
+def _has_inplace_pattern(mlir_text: str) -> bool:
+    """All three markers must appear together for the pattern to be valid."""
+    return (
+        "!torch.tensor<" in mlir_text
+        and "torch.overwrite.tensor.contents" in mlir_text
+        and "torch.copy.to_vtensor" in mlir_text
+    )
+
+
+def test_inplace_outputs_default_on(iree_device):
+    """Without setting the session option, the in-place pattern MUST be emitted."""
+    model, _, _ = _make_static_add_model()
+    mlir, err = try_generate_mlir(model, iree_device, "", "host")
+    assert err is None, err
+    assert _has_inplace_pattern(mlir), (
+        "in-place pattern missing from MLIR while option was at its "
+        "default (expected ON):\n" + mlir
+    )
+
+
+def test_inplace_outputs_explicit_disable(iree_device):
+    """Setting the session option to "0" MUST suppress the in-place pattern."""
+    model, _, _ = _make_static_add_model()
+    mlir, err = try_generate_mlir(
+        model,
+        iree_device,
+        "",
+        "host",
+        extra_provider_options={"enable_inplace_outputs": "0"},
+    )
+    assert err is None, err
+    assert not _has_inplace_pattern(
+        mlir
+    ), "in-place pattern leaked into MLIR while option was explicitly disabled"
+
+
+def test_inplace_outputs_numerical_parity(iree_device):
+    """Both modes must produce bit-identical results for the same inputs."""
+    model, a, b = _make_static_add_model()
+    with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+        onnx.save(model, f.name)
+        model_path = f.name
+
+    def _run(enable_inplace_opt: str) -> np.ndarray:
+        sess_opts = ort.SessionOptions()
+        sess_opts.add_provider_for_devices(
+            [iree_device],
+            {
+                "target_arch": "host",
+                "enable_inplace_outputs": enable_inplace_opt,
+            },
+        )
+        session = ort.InferenceSession(model_path, sess_options=sess_opts)
+        [out] = session.run(None, {"A": a})
+        return out
+
+    try:
+        out_off = _run("0")
+        out_on = _run("1")
+        np.testing.assert_array_equal(out_off, out_on)
+        np.testing.assert_array_equal(out_on, a + b)
+    finally:
+        pathlib.Path(model_path).unlink(missing_ok=True)

--- a/test/test_sanitize_names.py
+++ b/test/test_sanitize_names.py
@@ -106,3 +106,17 @@ def test_dollar_escaped_mlir(cpu_device, target_arch):
 
     assert "%a$24$2D$24$b" in mlir
     assert "%a$2D$b" in mlir
+
+
+def test_double_underscore_prefix_reserved_mlir(cpu_device, target_arch):
+    """The leading '__' prefix is reserved for internally-synthesized names."""
+    mlir = _generate_mlir(
+        ["__iree_ep_inplace_storage_0", "__plain"], cpu_device, target_arch
+    )
+
+    # '__iree_ep_inplace_storage_0' -> '$5F$_iree_ep_inplace_storage_0'
+    # '__plain'                     -> '$5F$_plain'
+    assert "%$5F$_iree_ep_inplace_storage_0" in mlir
+    assert "%$5F$_plain" in mlir
+    assert "%__iree_ep_inplace_storage_0:" not in mlir
+    assert "%__plain:" not in mlir


### PR DESCRIPTION
## Summary

Enables **output elision for static-shape outputs** in the IREE EP - eliminates one `stream.resource.alloca` and one post-execution device-to-device copy per tied output (for the example being tried to checked in via test*).

## Motivation

When user code pre-allocates output buffers (IO-binding), IREE's default lowering still allocates a fresh device buffer, has the dispatch write into it, then copies back into the user's buffer. This PR makes the dispatch write *directly* into the user-provided buffer on the hot path.

## Design

- **MLIR generator (`src/mlir_gen.cc`).** For every static-shape output, the emitted Torch MLIR is extended with:
  - an extra mutable storage arg `%out_C: !torch.tensor<[...],dtype>` appended after the regular inputs,
  - `torch.overwrite.tensor.contents %C overwrites %out_C` before the return, and
  - `%C__storage_vt = torch.copy.to_vtensor %out_C` that is returned in place of `%C`.

  This is the canonical Torch in-place pattern that IREE's pipeline recognizes and folds into the storage arg's buffer.

- **Runtime (`src/iree_ep.cc` `ComputeImpl`).** For each tied output, the ORT-allocated output buffer view is pushed into the IREE input list at the matching position *before* invoke, and the usual post-execution copy-back is skipped.

- **Safety fallback.** If an ORT output buffer lives on a non-IREE device (common on CPU-only / non-IO-bound paths), the EP silently falls back to the legacy alloca + copy-back path for that output.

- **Flag control** `ep.iree.enable_inplace_outputs` session option, default `"1"`. Set `"0"` to bypass the emission entirely.


## Effect at the IR level

Small static-shape Add (`64x64xf32 + constant`).
Stream dialect :-

**Without** (baseline, `stream.resource.alloca` count = 1):

```mlir
// signature: (input, wait_fence, signal_fence) -> result_buffer_view
util.func private @...$async(%arg0: !hal.buffer_view,
                             %arg1: !hal.fence,
                             %arg2: !hal.fence) -> !hal.buffer_view ... {
  %0 = stream.tensor.import ... %arg0 : !hal.buffer_view -> tensor<64x64xf32>
                                      in !stream.resource<external>{%c16384}
  %1 = stream.timepoint.import ... %arg1 : (!hal.fence) => !stream.timepoint

  // <-- fresh device buffer for the result
  %result, %result_timepoint = stream.resource.alloca uninitialized
                             ... => !stream.resource<external>{%c16384}

  %2 = stream.cmd.execute ... with(%0     as %arg3: ...,   // input
                                   %const as %arg4: ...,   // constant
                                   %result as %arg5: ...)  // our alloca
  {
    stream.cmd.dispatch ... {
      ro %arg3[...] : ...,
      ro %arg4[...] : ...,
      wo %arg5[...] : ...        // <-- writeonly into the alloca
    }
  } => !stream.timepoint

  %3 = stream.tensor.export ... %result : ... -> !hal.buffer_view
  util.return %3 : !hal.buffer_view   // ORT then copies this back into the
                                      // user's output buffer
}
```

**With** (this PR, `stream.resource.alloca` count = 0):

```mlir
// signature adds an extra %arg1 for the caller-provided output buffer:
// (input, output_storage, wait_fence, signal_fence) -> result_buffer_view
util.func private @...$async(%arg0: !hal.buffer_view,
                             %arg1: !hal.buffer_view,   // <-- user's output
                             %arg2: !hal.fence,
                             %arg3: !hal.fence) -> !hal.buffer_view ... {
  %0 = stream.tensor.import ... %arg0 : !hal.buffer_view -> tensor<64x64xf32>
                                      in !stream.resource<external>{%c16384}
  %1 = stream.timepoint.import ... %arg2 : (!hal.fence) => !stream.timepoint
  %2 = stream.tensor.import ... %arg1 : !hal.buffer_view -> tensor<64x64xf32>
                                      in !stream.resource<external>{%c16384}
  // ^ user's output buffer imported as a second input resource
  // (note: no stream.resource.alloca)

  %3 = stream.cmd.execute ... with(%0     as %arg4: ...,   // input
                                   %const as %arg5: ...,   // constant
                                   %2     as %arg6: ...)   // user's buffer
  {
    stream.cmd.dispatch ... {
      ro %arg4[...] : ...,
      ro %arg5[...] : ...,
      rw %arg6[...] : ...        // <-- read-write on the user's buffer
    }
  } => !stream.timepoint

  util.return %arg1 : !hal.buffer_view   // returns the user's buffer itself
                                         // (no export, no copy-back)
}
```

Note the output-binding operand type: `wo` -> `rw`.
`stream.tensor.export` of a fresh buffer is replaced by `util.return %arg1` of the caller's own buffer.

I have a better design in mind which will solve static and dynamic shapes both - will work on it next.